### PR TITLE
add build files into repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,7 @@
 /node_modules/
 
 # tree-sitter generate
-!/src/
-/src/*
-!/src/scanner.cc
-/bindings/
-/Cargo.toml
-binding.gyp
+build/
 
 # tree-sitter build-wasm
 /tree-sitter-d.wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tree-sitter-d"
+description = "d grammar for the tree-sitter parsing library"
+version = "0.0.1"
+keywords = ["incremental", "parsing", "d"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-d"
+edition = "2018"
+license = "MIT"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "queries/*",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "~0.20.0"
+
+[build-dependencies]
+cc = "1.0"

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,19 @@
+{
+  "targets": [
+    {
+      "target_name": "tree_sitter_d_binding",
+      "include_dirs": [
+        "<!(node -e \"require('nan')\")",
+        "src"
+      ],
+      "sources": [
+        "bindings/node/binding.cc",
+        "src/parser.c",
+        "src/scanner.cc",
+      ],
+      "cflags_c": [
+        "-std=c99",
+      ]
+    }
+  ]
+}

--- a/bindings/node/binding.cc
+++ b/bindings/node/binding.cc
@@ -1,0 +1,28 @@
+#include "tree_sitter/parser.h"
+#include <node.h>
+#include "nan.h"
+
+using namespace v8;
+
+extern "C" TSLanguage * tree_sitter_d();
+
+namespace {
+
+NAN_METHOD(New) {}
+
+void Init(Local<Object> exports, Local<Object> module) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("Language").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
+  Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
+  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_d());
+
+  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("d").ToLocalChecked());
+  Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
+}
+
+NODE_MODULE(tree_sitter_d_binding, Init)
+
+}  // namespace

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,0 +1,19 @@
+try {
+  module.exports = require("../../build/Release/tree_sitter_d_binding");
+} catch (error1) {
+  if (error1.code !== 'MODULE_NOT_FOUND') {
+    throw error1;
+  }
+  try {
+    module.exports = require("../../build/Debug/tree_sitter_d_binding");
+  } catch (error2) {
+    if (error2.code !== 'MODULE_NOT_FOUND') {
+      throw error2;
+    }
+    throw error1
+  }
+}
+
+try {
+  module.exports.nodeTypeInfo = require("../../src/node-types.json");
+} catch (_) {}

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+
+    // If your language uses an external scanner written in C,
+    // then include this block of code:
+
+    /*
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    // If your language uses an external scanner written in C++,
+    // then include this block of code:
+
+    /*
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    cpp_config.compile("scanner");
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+}

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -25,7 +25,6 @@ fn main() {
     // If your language uses an external scanner written in C++,
     // then include this block of code:
 
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +35,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     cpp_config.compile("scanner");
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,52 @@
+//! This crate provides d language support for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this language to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! let code = "";
+//! let mut parser = tree_sitter::Parser::new();
+//! parser.set_language(tree_sitter_d::language()).expect("Error loading d grammar");
+//! let tree = parser.parse(code, None).unwrap();
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_d() -> Language;
+}
+
+/// Get the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_d() }
+}
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+// Uncomment these to include any queries that this grammar contains
+
+// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading d language");
+    }
+}

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,0 +1,22157 @@
+{
+  "name": "d",
+  "word": "identifier",
+  "rules": {
+    "source_file": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "byte_order_mark"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "shebang"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "module"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "byte_order_mark": {
+      "type": "TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "﻿"
+      }
+    },
+    "shebang": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "#!"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "."
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\n"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\u001a"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_end_of_line": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\r"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\n"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "\n"
+          },
+          {
+            "type": "STRING",
+            "value": " "
+          },
+          {
+            "type": "STRING",
+            "value": " "
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\u001a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_white_space": {
+      "type": "TOKEN",
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": " "
+            },
+            {
+              "type": "STRING",
+              "value": "\t"
+            },
+            {
+              "type": "STRING",
+              "value": "\u000b"
+            },
+            {
+              "type": "STRING",
+              "value": "\f"
+            }
+          ]
+        }
+      }
+    },
+    "comment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "block_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "line_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nesting_block_comment"
+        }
+      ]
+    },
+    "block_comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "/*"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^*]*[*]+(?:[^/*][^*]*[*]+)*"
+          },
+          {
+            "type": "STRING",
+            "value": "/"
+          }
+        ]
+      }
+    },
+    "line_comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "//"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "."
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\r"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\n"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "\n"
+              },
+              {
+                "type": "STRING",
+                "value": " "
+              },
+              {
+                "type": "STRING",
+                "value": " "
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\u001a"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "token_no_braces": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "character_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword"
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "STRING",
+          "value": "/="
+        },
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "STRING",
+          "value": ".."
+        },
+        {
+          "type": "STRING",
+          "value": "..."
+        },
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "STRING",
+          "value": "&="
+        },
+        {
+          "type": "STRING",
+          "value": "&&"
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "STRING",
+          "value": "|="
+        },
+        {
+          "type": "STRING",
+          "value": "||"
+        },
+        {
+          "type": "STRING",
+          "value": "-"
+        },
+        {
+          "type": "STRING",
+          "value": "-="
+        },
+        {
+          "type": "STRING",
+          "value": "--"
+        },
+        {
+          "type": "STRING",
+          "value": "+"
+        },
+        {
+          "type": "STRING",
+          "value": "+="
+        },
+        {
+          "type": "STRING",
+          "value": "++"
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": "<="
+        },
+        {
+          "type": "STRING",
+          "value": "<<"
+        },
+        {
+          "type": "STRING",
+          "value": "<<="
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": ">="
+        },
+        {
+          "type": "STRING",
+          "value": ">>="
+        },
+        {
+          "type": "STRING",
+          "value": ">>>="
+        },
+        {
+          "type": "STRING",
+          "value": ">>"
+        },
+        {
+          "type": "STRING",
+          "value": ">>>"
+        },
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "STRING",
+          "value": "!="
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        },
+        {
+          "type": "STRING",
+          "value": "?"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "STRING",
+          "value": "$"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "*="
+        },
+        {
+          "type": "STRING",
+          "value": "%"
+        },
+        {
+          "type": "STRING",
+          "value": "%="
+        },
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "STRING",
+          "value": "^="
+        },
+        {
+          "type": "STRING",
+          "value": "^^"
+        },
+        {
+          "type": "STRING",
+          "value": "^^="
+        },
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "STRING",
+          "value": "~="
+        },
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "STRING",
+          "value": "#"
+        }
+      ]
+    },
+    "identifier": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "_"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[A-Za-z]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[\\u00aa\\u00b5\\u00b7\\u00ba\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u01f5\\u01fa-\\u0217\\u0250-\\u02a8\\u02b0-\\u02b8\\u02bb\\u02bd-\\u02c1\\u02d0-\\u02d1\\u02e0-\\u02e4\\u037a\\u0386\\u0388-\\u038a\\u038c\\u038e-\\u03a1\\u03a3-\\u03ce\\u03d0-\\u03d6\\u03da\\u03dc\\u03de\\u03e0\\u03e2-\\u03f3\\u0401-\\u040c\\u040e-\\u044f\\u0451-\\u045c\\u045e-\\u0481\\u0490-\\u04c4\\u04c7-\\u04c8\\u04cb-\\u04cc\\u04d0-\\u04eb\\u04ee-\\u04f5\\u04f8-\\u04f9\\u0531-\\u0556\\u0559\\u0561-\\u0587\\u05b0-\\u05b9\\u05bb-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05d0-\\u05ea\\u05f0-\\u05f2\\u0621-\\u063a\\u0640-\\u0652\\u0660-\\u0669\\u0670-\\u06b7\\u06ba-\\u06be\\u06c0-\\u06ce\\u06d0-\\u06dc\\u06e5-\\u06e8\\u06ea-\\u06ed\\u06f0-\\u06f9\\u0901-\\u0903\\u0905-\\u0939\\u093d-\\u094d\\u0950-\\u0952\\u0958-\\u0963\\u0966-\\u096f\\u0981-\\u0983\\u0985-\\u098c\\u098f-\\u0990\\u0993-\\u09a8\\u09aa-\\u09b0\\u09b2\\u09b6-\\u09b9\\u09be-\\u09c4\\u09c7-\\u09c8\\u09cb-\\u09cd\\u09dc-\\u09dd\\u09df-\\u09e3\\u09e6-\\u09f1\\u0a02\\u0a05-\\u0a0a\\u0a0f-\\u0a10\\u0a13-\\u0a28\\u0a2a-\\u0a30\\u0a32-\\u0a33\\u0a35-\\u0a36\\u0a38-\\u0a39\\u0a3e-\\u0a42\\u0a47-\\u0a48\\u0a4b-\\u0a4d\\u0a59-\\u0a5c\\u0a5e\\u0a66-\\u0a6f\\u0a74\\u0a81-\\u0a83\\u0a85-\\u0a8b\\u0a8d\\u0a8f-\\u0a91\\u0a93-\\u0aa8\\u0aaa-\\u0ab0\\u0ab2-\\u0ab3\\u0ab5-\\u0ab9\\u0abd-\\u0ac5\\u0ac7-\\u0ac9\\u0acb-\\u0acd\\u0ad0\\u0ae0\\u0ae6-\\u0aef\\u0b01-\\u0b03\\u0b05-\\u0b0c\\u0b0f-\\u0b10\\u0b13-\\u0b28\\u0b2a-\\u0b30\\u0b32-\\u0b33\\u0b36-\\u0b39\\u0b3d-\\u0b43\\u0b47-\\u0b48\\u0b4b-\\u0b4d\\u0b5c-\\u0b5d\\u0b5f-\\u0b61\\u0b66-\\u0b6f\\u0b82-\\u0b83\\u0b85-\\u0b8a\\u0b8e-\\u0b90\\u0b92-\\u0b95\\u0b99-\\u0b9a\\u0b9c\\u0b9e-\\u0b9f\\u0ba3-\\u0ba4\\u0ba8-\\u0baa\\u0bae-\\u0bb5\\u0bb7-\\u0bb9\\u0bbe-\\u0bc2\\u0bc6-\\u0bc8\\u0bca-\\u0bcd\\u0be7-\\u0bef\\u0c01-\\u0c03\\u0c05-\\u0c0c\\u0c0e-\\u0c10\\u0c12-\\u0c28\\u0c2a-\\u0c33\\u0c35-\\u0c39\\u0c3e-\\u0c44\\u0c46-\\u0c48\\u0c4a-\\u0c4d\\u0c60-\\u0c61\\u0c66-\\u0c6f\\u0c82-\\u0c83\\u0c85-\\u0c8c\\u0c8e-\\u0c90\\u0c92-\\u0ca8\\u0caa-\\u0cb3\\u0cb5-\\u0cb9\\u0cbe-\\u0cc4\\u0cc6-\\u0cc8\\u0cca-\\u0ccd\\u0cde\\u0ce0-\\u0ce1\\u0ce6-\\u0cef\\u0d02-\\u0d03\\u0d05-\\u0d0c\\u0d0e-\\u0d10\\u0d12-\\u0d28\\u0d2a-\\u0d39\\u0d3e-\\u0d43\\u0d46-\\u0d48\\u0d4a-\\u0d4d\\u0d60-\\u0d61\\u0d66-\\u0d6f\\u0e01-\\u0e3a\\u0e40-\\u0e5b\\u0e81-\\u0e82\\u0e84\\u0e87-\\u0e88\\u0e8a\\u0e8d\\u0e94-\\u0e97\\u0e99-\\u0e9f\\u0ea1-\\u0ea3\\u0ea5\\u0ea7\\u0eaa-\\u0eab\\u0ead-\\u0eae\\u0eb0-\\u0eb9\\u0ebb-\\u0ebd\\u0ec0-\\u0ec4\\u0ec6\\u0ec8-\\u0ecd\\u0ed0-\\u0ed9\\u0edc-\\u0edd\\u0f00\\u0f18-\\u0f19\\u0f20-\\u0f33\\u0f35\\u0f37\\u0f39\\u0f3e-\\u0f47\\u0f49-\\u0f69\\u0f71-\\u0f84\\u0f86-\\u0f8b\\u0f90-\\u0f95\\u0f97\\u0f99-\\u0fad\\u0fb1-\\u0fb7\\u0fb9\\u10a0-\\u10c5\\u10d0-\\u10f6\\u1e00-\\u1e9b\\u1ea0-\\u1ef9\\u1f00-\\u1f15\\u1f18-\\u1f1d\\u1f20-\\u1f45\\u1f48-\\u1f4d\\u1f50-\\u1f57\\u1f59\\u1f5b\\u1f5d\\u1f5f-\\u1f7d\\u1f80-\\u1fb4\\u1fb6-\\u1fbc\\u1fbe\\u1fc2-\\u1fc4\\u1fc6-\\u1fcc\\u1fd0-\\u1fd3\\u1fd6-\\u1fdb\\u1fe0-\\u1fec\\u1ff2-\\u1ff4\\u1ff6-\\u1ffc\\u203f-\\u2040\\u207f\\u2102\\u2107\\u210a-\\u2113\\u2115\\u2118-\\u211d\\u2124\\u2126\\u2128\\u212a-\\u2131\\u2133-\\u2138\\u2160-\\u2182\\u3005-\\u3007\\u3021-\\u3029\\u3041-\\u3093\\u309b-\\u309c\\u30a1-\\u30f6\\u30fb-\\u30fc\\u3105-\\u312c\\u4e00-\\u9fa5\\uac00-\\ud7a3]"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "_"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "[A-Za-z]"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "[\\u00aa\\u00b5\\u00b7\\u00ba\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u01f5\\u01fa-\\u0217\\u0250-\\u02a8\\u02b0-\\u02b8\\u02bb\\u02bd-\\u02c1\\u02d0-\\u02d1\\u02e0-\\u02e4\\u037a\\u0386\\u0388-\\u038a\\u038c\\u038e-\\u03a1\\u03a3-\\u03ce\\u03d0-\\u03d6\\u03da\\u03dc\\u03de\\u03e0\\u03e2-\\u03f3\\u0401-\\u040c\\u040e-\\u044f\\u0451-\\u045c\\u045e-\\u0481\\u0490-\\u04c4\\u04c7-\\u04c8\\u04cb-\\u04cc\\u04d0-\\u04eb\\u04ee-\\u04f5\\u04f8-\\u04f9\\u0531-\\u0556\\u0559\\u0561-\\u0587\\u05b0-\\u05b9\\u05bb-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05d0-\\u05ea\\u05f0-\\u05f2\\u0621-\\u063a\\u0640-\\u0652\\u0660-\\u0669\\u0670-\\u06b7\\u06ba-\\u06be\\u06c0-\\u06ce\\u06d0-\\u06dc\\u06e5-\\u06e8\\u06ea-\\u06ed\\u06f0-\\u06f9\\u0901-\\u0903\\u0905-\\u0939\\u093d-\\u094d\\u0950-\\u0952\\u0958-\\u0963\\u0966-\\u096f\\u0981-\\u0983\\u0985-\\u098c\\u098f-\\u0990\\u0993-\\u09a8\\u09aa-\\u09b0\\u09b2\\u09b6-\\u09b9\\u09be-\\u09c4\\u09c7-\\u09c8\\u09cb-\\u09cd\\u09dc-\\u09dd\\u09df-\\u09e3\\u09e6-\\u09f1\\u0a02\\u0a05-\\u0a0a\\u0a0f-\\u0a10\\u0a13-\\u0a28\\u0a2a-\\u0a30\\u0a32-\\u0a33\\u0a35-\\u0a36\\u0a38-\\u0a39\\u0a3e-\\u0a42\\u0a47-\\u0a48\\u0a4b-\\u0a4d\\u0a59-\\u0a5c\\u0a5e\\u0a66-\\u0a6f\\u0a74\\u0a81-\\u0a83\\u0a85-\\u0a8b\\u0a8d\\u0a8f-\\u0a91\\u0a93-\\u0aa8\\u0aaa-\\u0ab0\\u0ab2-\\u0ab3\\u0ab5-\\u0ab9\\u0abd-\\u0ac5\\u0ac7-\\u0ac9\\u0acb-\\u0acd\\u0ad0\\u0ae0\\u0ae6-\\u0aef\\u0b01-\\u0b03\\u0b05-\\u0b0c\\u0b0f-\\u0b10\\u0b13-\\u0b28\\u0b2a-\\u0b30\\u0b32-\\u0b33\\u0b36-\\u0b39\\u0b3d-\\u0b43\\u0b47-\\u0b48\\u0b4b-\\u0b4d\\u0b5c-\\u0b5d\\u0b5f-\\u0b61\\u0b66-\\u0b6f\\u0b82-\\u0b83\\u0b85-\\u0b8a\\u0b8e-\\u0b90\\u0b92-\\u0b95\\u0b99-\\u0b9a\\u0b9c\\u0b9e-\\u0b9f\\u0ba3-\\u0ba4\\u0ba8-\\u0baa\\u0bae-\\u0bb5\\u0bb7-\\u0bb9\\u0bbe-\\u0bc2\\u0bc6-\\u0bc8\\u0bca-\\u0bcd\\u0be7-\\u0bef\\u0c01-\\u0c03\\u0c05-\\u0c0c\\u0c0e-\\u0c10\\u0c12-\\u0c28\\u0c2a-\\u0c33\\u0c35-\\u0c39\\u0c3e-\\u0c44\\u0c46-\\u0c48\\u0c4a-\\u0c4d\\u0c60-\\u0c61\\u0c66-\\u0c6f\\u0c82-\\u0c83\\u0c85-\\u0c8c\\u0c8e-\\u0c90\\u0c92-\\u0ca8\\u0caa-\\u0cb3\\u0cb5-\\u0cb9\\u0cbe-\\u0cc4\\u0cc6-\\u0cc8\\u0cca-\\u0ccd\\u0cde\\u0ce0-\\u0ce1\\u0ce6-\\u0cef\\u0d02-\\u0d03\\u0d05-\\u0d0c\\u0d0e-\\u0d10\\u0d12-\\u0d28\\u0d2a-\\u0d39\\u0d3e-\\u0d43\\u0d46-\\u0d48\\u0d4a-\\u0d4d\\u0d60-\\u0d61\\u0d66-\\u0d6f\\u0e01-\\u0e3a\\u0e40-\\u0e5b\\u0e81-\\u0e82\\u0e84\\u0e87-\\u0e88\\u0e8a\\u0e8d\\u0e94-\\u0e97\\u0e99-\\u0e9f\\u0ea1-\\u0ea3\\u0ea5\\u0ea7\\u0eaa-\\u0eab\\u0ead-\\u0eae\\u0eb0-\\u0eb9\\u0ebb-\\u0ebd\\u0ec0-\\u0ec4\\u0ec6\\u0ec8-\\u0ecd\\u0ed0-\\u0ed9\\u0edc-\\u0edd\\u0f00\\u0f18-\\u0f19\\u0f20-\\u0f33\\u0f35\\u0f37\\u0f39\\u0f3e-\\u0f47\\u0f49-\\u0f69\\u0f71-\\u0f84\\u0f86-\\u0f8b\\u0f90-\\u0f95\\u0f97\\u0f99-\\u0fad\\u0fb1-\\u0fb7\\u0fb9\\u10a0-\\u10c5\\u10d0-\\u10f6\\u1e00-\\u1e9b\\u1ea0-\\u1ef9\\u1f00-\\u1f15\\u1f18-\\u1f1d\\u1f20-\\u1f45\\u1f48-\\u1f4d\\u1f50-\\u1f57\\u1f59\\u1f5b\\u1f5d\\u1f5f-\\u1f7d\\u1f80-\\u1fb4\\u1fb6-\\u1fbc\\u1fbe\\u1fc2-\\u1fc4\\u1fc6-\\u1fcc\\u1fd0-\\u1fd3\\u1fd6-\\u1fdb\\u1fe0-\\u1fec\\u1ff2-\\u1ff4\\u1ff6-\\u1ffc\\u203f-\\u2040\\u207f\\u2102\\u2107\\u210a-\\u2113\\u2115\\u2118-\\u211d\\u2124\\u2126\\u2128\\u212a-\\u2131\\u2133-\\u2138\\u2160-\\u2182\\u3005-\\u3007\\u3021-\\u3029\\u3041-\\u3093\\u309b-\\u309c\\u30a1-\\u30f6\\u30fb-\\u30fc\\u3105-\\u312c\\u4e00-\\u9fa5\\uac00-\\ud7a3]"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "0"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "1"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "2"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "3"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "4"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "5"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "6"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "7"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "8"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "9"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_string_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "wysiwyg_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alternate_wysiwyg_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "double_quoted_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hex_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "delimited_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "token_string"
+        }
+      ]
+    },
+    "wysiwyg_string": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "r\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[^\"]"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "c"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "w"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "d"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "alternate_wysiwyg_string": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "`"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^`]*"
+          },
+          {
+            "type": "STRING",
+            "value": "`"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "c"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "w"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "d"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "double_quoted_string": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[^\"\\\\]"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "\\'"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\\""
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\?"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\\\"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\0"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\a"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\b"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\f"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\n"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\r"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\t"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\v"
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "\\x"
+                                },
+                                {
+                                  "type": "SEQ",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\u"
+                                        },
+                                        {
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "\\U"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "a"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "b"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "c"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "d"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "e"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "f"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "A"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "B"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "C"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "D"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "E"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "F"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "a"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "b"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "c"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "d"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "e"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "f"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "A"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "B"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "C"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "D"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "E"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "F"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "a"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "b"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "c"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "d"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "e"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "f"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "A"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "B"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "C"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "D"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "E"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "F"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "a"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "b"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "c"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "d"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "e"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "f"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "A"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "B"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "C"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "D"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "E"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "F"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "0"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "8"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "9"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "a"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "b"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "c"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "d"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "e"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "f"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "A"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "B"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "C"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "D"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "E"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "F"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "0"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "8"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "9"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "a"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "b"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "c"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "d"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "e"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "f"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "A"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "B"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "C"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "D"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "E"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "F"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "0"
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "1"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "2"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "3"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "4"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "5"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "6"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "7"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "8"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "9"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "a"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "b"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "c"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "d"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "e"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "f"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "A"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "B"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "C"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "D"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "E"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "F"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "0"
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "1"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "2"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "3"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "4"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "5"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "6"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "7"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "8"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "9"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "a"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "b"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "c"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "d"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "e"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "f"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "A"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "B"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "C"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "D"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "E"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "F"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\\"
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SEQ",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "0"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "1"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "2"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "3"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "4"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "5"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "6"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "7"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "0"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "1"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "2"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "3"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "4"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "5"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "6"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "7"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "BLANK"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "BLANK"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "SEQ",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "&"
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "_"
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "[A-Za-z]"
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "[\\u00aa\\u00b5\\u00b7\\u00ba\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u01f5\\u01fa-\\u0217\\u0250-\\u02a8\\u02b0-\\u02b8\\u02bb\\u02bd-\\u02c1\\u02d0-\\u02d1\\u02e0-\\u02e4\\u037a\\u0386\\u0388-\\u038a\\u038c\\u038e-\\u03a1\\u03a3-\\u03ce\\u03d0-\\u03d6\\u03da\\u03dc\\u03de\\u03e0\\u03e2-\\u03f3\\u0401-\\u040c\\u040e-\\u044f\\u0451-\\u045c\\u045e-\\u0481\\u0490-\\u04c4\\u04c7-\\u04c8\\u04cb-\\u04cc\\u04d0-\\u04eb\\u04ee-\\u04f5\\u04f8-\\u04f9\\u0531-\\u0556\\u0559\\u0561-\\u0587\\u05b0-\\u05b9\\u05bb-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05d0-\\u05ea\\u05f0-\\u05f2\\u0621-\\u063a\\u0640-\\u0652\\u0660-\\u0669\\u0670-\\u06b7\\u06ba-\\u06be\\u06c0-\\u06ce\\u06d0-\\u06dc\\u06e5-\\u06e8\\u06ea-\\u06ed\\u06f0-\\u06f9\\u0901-\\u0903\\u0905-\\u0939\\u093d-\\u094d\\u0950-\\u0952\\u0958-\\u0963\\u0966-\\u096f\\u0981-\\u0983\\u0985-\\u098c\\u098f-\\u0990\\u0993-\\u09a8\\u09aa-\\u09b0\\u09b2\\u09b6-\\u09b9\\u09be-\\u09c4\\u09c7-\\u09c8\\u09cb-\\u09cd\\u09dc-\\u09dd\\u09df-\\u09e3\\u09e6-\\u09f1\\u0a02\\u0a05-\\u0a0a\\u0a0f-\\u0a10\\u0a13-\\u0a28\\u0a2a-\\u0a30\\u0a32-\\u0a33\\u0a35-\\u0a36\\u0a38-\\u0a39\\u0a3e-\\u0a42\\u0a47-\\u0a48\\u0a4b-\\u0a4d\\u0a59-\\u0a5c\\u0a5e\\u0a66-\\u0a6f\\u0a74\\u0a81-\\u0a83\\u0a85-\\u0a8b\\u0a8d\\u0a8f-\\u0a91\\u0a93-\\u0aa8\\u0aaa-\\u0ab0\\u0ab2-\\u0ab3\\u0ab5-\\u0ab9\\u0abd-\\u0ac5\\u0ac7-\\u0ac9\\u0acb-\\u0acd\\u0ad0\\u0ae0\\u0ae6-\\u0aef\\u0b01-\\u0b03\\u0b05-\\u0b0c\\u0b0f-\\u0b10\\u0b13-\\u0b28\\u0b2a-\\u0b30\\u0b32-\\u0b33\\u0b36-\\u0b39\\u0b3d-\\u0b43\\u0b47-\\u0b48\\u0b4b-\\u0b4d\\u0b5c-\\u0b5d\\u0b5f-\\u0b61\\u0b66-\\u0b6f\\u0b82-\\u0b83\\u0b85-\\u0b8a\\u0b8e-\\u0b90\\u0b92-\\u0b95\\u0b99-\\u0b9a\\u0b9c\\u0b9e-\\u0b9f\\u0ba3-\\u0ba4\\u0ba8-\\u0baa\\u0bae-\\u0bb5\\u0bb7-\\u0bb9\\u0bbe-\\u0bc2\\u0bc6-\\u0bc8\\u0bca-\\u0bcd\\u0be7-\\u0bef\\u0c01-\\u0c03\\u0c05-\\u0c0c\\u0c0e-\\u0c10\\u0c12-\\u0c28\\u0c2a-\\u0c33\\u0c35-\\u0c39\\u0c3e-\\u0c44\\u0c46-\\u0c48\\u0c4a-\\u0c4d\\u0c60-\\u0c61\\u0c66-\\u0c6f\\u0c82-\\u0c83\\u0c85-\\u0c8c\\u0c8e-\\u0c90\\u0c92-\\u0ca8\\u0caa-\\u0cb3\\u0cb5-\\u0cb9\\u0cbe-\\u0cc4\\u0cc6-\\u0cc8\\u0cca-\\u0ccd\\u0cde\\u0ce0-\\u0ce1\\u0ce6-\\u0cef\\u0d02-\\u0d03\\u0d05-\\u0d0c\\u0d0e-\\u0d10\\u0d12-\\u0d28\\u0d2a-\\u0d39\\u0d3e-\\u0d43\\u0d46-\\u0d48\\u0d4a-\\u0d4d\\u0d60-\\u0d61\\u0d66-\\u0d6f\\u0e01-\\u0e3a\\u0e40-\\u0e5b\\u0e81-\\u0e82\\u0e84\\u0e87-\\u0e88\\u0e8a\\u0e8d\\u0e94-\\u0e97\\u0e99-\\u0e9f\\u0ea1-\\u0ea3\\u0ea5\\u0ea7\\u0eaa-\\u0eab\\u0ead-\\u0eae\\u0eb0-\\u0eb9\\u0ebb-\\u0ebd\\u0ec0-\\u0ec4\\u0ec6\\u0ec8-\\u0ecd\\u0ed0-\\u0ed9\\u0edc-\\u0edd\\u0f00\\u0f18-\\u0f19\\u0f20-\\u0f33\\u0f35\\u0f37\\u0f39\\u0f3e-\\u0f47\\u0f49-\\u0f69\\u0f71-\\u0f84\\u0f86-\\u0f8b\\u0f90-\\u0f95\\u0f97\\u0f99-\\u0fad\\u0fb1-\\u0fb7\\u0fb9\\u10a0-\\u10c5\\u10d0-\\u10f6\\u1e00-\\u1e9b\\u1ea0-\\u1ef9\\u1f00-\\u1f15\\u1f18-\\u1f1d\\u1f20-\\u1f45\\u1f48-\\u1f4d\\u1f50-\\u1f57\\u1f59\\u1f5b\\u1f5d\\u1f5f-\\u1f7d\\u1f80-\\u1fb4\\u1fb6-\\u1fbc\\u1fbe\\u1fc2-\\u1fc4\\u1fc6-\\u1fcc\\u1fd0-\\u1fd3\\u1fd6-\\u1fdb\\u1fe0-\\u1fec\\u1ff2-\\u1ff4\\u1ff6-\\u1ffc\\u203f-\\u2040\\u207f\\u2102\\u2107\\u210a-\\u2113\\u2115\\u2118-\\u211d\\u2124\\u2126\\u2128\\u212a-\\u2131\\u2133-\\u2138\\u2160-\\u2182\\u3005-\\u3007\\u3021-\\u3029\\u3041-\\u3093\\u309b-\\u309c\\u30a1-\\u30f6\\u30fb-\\u30fc\\u3105-\\u312c\\u4e00-\\u9fa5\\uac00-\\ud7a3]"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "REPEAT1",
+                                              "content": {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "_"
+                                                      },
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[A-Za-z]"
+                                                      },
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[\\u00aa\\u00b5\\u00b7\\u00ba\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u01f5\\u01fa-\\u0217\\u0250-\\u02a8\\u02b0-\\u02b8\\u02bb\\u02bd-\\u02c1\\u02d0-\\u02d1\\u02e0-\\u02e4\\u037a\\u0386\\u0388-\\u038a\\u038c\\u038e-\\u03a1\\u03a3-\\u03ce\\u03d0-\\u03d6\\u03da\\u03dc\\u03de\\u03e0\\u03e2-\\u03f3\\u0401-\\u040c\\u040e-\\u044f\\u0451-\\u045c\\u045e-\\u0481\\u0490-\\u04c4\\u04c7-\\u04c8\\u04cb-\\u04cc\\u04d0-\\u04eb\\u04ee-\\u04f5\\u04f8-\\u04f9\\u0531-\\u0556\\u0559\\u0561-\\u0587\\u05b0-\\u05b9\\u05bb-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05d0-\\u05ea\\u05f0-\\u05f2\\u0621-\\u063a\\u0640-\\u0652\\u0660-\\u0669\\u0670-\\u06b7\\u06ba-\\u06be\\u06c0-\\u06ce\\u06d0-\\u06dc\\u06e5-\\u06e8\\u06ea-\\u06ed\\u06f0-\\u06f9\\u0901-\\u0903\\u0905-\\u0939\\u093d-\\u094d\\u0950-\\u0952\\u0958-\\u0963\\u0966-\\u096f\\u0981-\\u0983\\u0985-\\u098c\\u098f-\\u0990\\u0993-\\u09a8\\u09aa-\\u09b0\\u09b2\\u09b6-\\u09b9\\u09be-\\u09c4\\u09c7-\\u09c8\\u09cb-\\u09cd\\u09dc-\\u09dd\\u09df-\\u09e3\\u09e6-\\u09f1\\u0a02\\u0a05-\\u0a0a\\u0a0f-\\u0a10\\u0a13-\\u0a28\\u0a2a-\\u0a30\\u0a32-\\u0a33\\u0a35-\\u0a36\\u0a38-\\u0a39\\u0a3e-\\u0a42\\u0a47-\\u0a48\\u0a4b-\\u0a4d\\u0a59-\\u0a5c\\u0a5e\\u0a66-\\u0a6f\\u0a74\\u0a81-\\u0a83\\u0a85-\\u0a8b\\u0a8d\\u0a8f-\\u0a91\\u0a93-\\u0aa8\\u0aaa-\\u0ab0\\u0ab2-\\u0ab3\\u0ab5-\\u0ab9\\u0abd-\\u0ac5\\u0ac7-\\u0ac9\\u0acb-\\u0acd\\u0ad0\\u0ae0\\u0ae6-\\u0aef\\u0b01-\\u0b03\\u0b05-\\u0b0c\\u0b0f-\\u0b10\\u0b13-\\u0b28\\u0b2a-\\u0b30\\u0b32-\\u0b33\\u0b36-\\u0b39\\u0b3d-\\u0b43\\u0b47-\\u0b48\\u0b4b-\\u0b4d\\u0b5c-\\u0b5d\\u0b5f-\\u0b61\\u0b66-\\u0b6f\\u0b82-\\u0b83\\u0b85-\\u0b8a\\u0b8e-\\u0b90\\u0b92-\\u0b95\\u0b99-\\u0b9a\\u0b9c\\u0b9e-\\u0b9f\\u0ba3-\\u0ba4\\u0ba8-\\u0baa\\u0bae-\\u0bb5\\u0bb7-\\u0bb9\\u0bbe-\\u0bc2\\u0bc6-\\u0bc8\\u0bca-\\u0bcd\\u0be7-\\u0bef\\u0c01-\\u0c03\\u0c05-\\u0c0c\\u0c0e-\\u0c10\\u0c12-\\u0c28\\u0c2a-\\u0c33\\u0c35-\\u0c39\\u0c3e-\\u0c44\\u0c46-\\u0c48\\u0c4a-\\u0c4d\\u0c60-\\u0c61\\u0c66-\\u0c6f\\u0c82-\\u0c83\\u0c85-\\u0c8c\\u0c8e-\\u0c90\\u0c92-\\u0ca8\\u0caa-\\u0cb3\\u0cb5-\\u0cb9\\u0cbe-\\u0cc4\\u0cc6-\\u0cc8\\u0cca-\\u0ccd\\u0cde\\u0ce0-\\u0ce1\\u0ce6-\\u0cef\\u0d02-\\u0d03\\u0d05-\\u0d0c\\u0d0e-\\u0d10\\u0d12-\\u0d28\\u0d2a-\\u0d39\\u0d3e-\\u0d43\\u0d46-\\u0d48\\u0d4a-\\u0d4d\\u0d60-\\u0d61\\u0d66-\\u0d6f\\u0e01-\\u0e3a\\u0e40-\\u0e5b\\u0e81-\\u0e82\\u0e84\\u0e87-\\u0e88\\u0e8a\\u0e8d\\u0e94-\\u0e97\\u0e99-\\u0e9f\\u0ea1-\\u0ea3\\u0ea5\\u0ea7\\u0eaa-\\u0eab\\u0ead-\\u0eae\\u0eb0-\\u0eb9\\u0ebb-\\u0ebd\\u0ec0-\\u0ec4\\u0ec6\\u0ec8-\\u0ecd\\u0ed0-\\u0ed9\\u0edc-\\u0edd\\u0f00\\u0f18-\\u0f19\\u0f20-\\u0f33\\u0f35\\u0f37\\u0f39\\u0f3e-\\u0f47\\u0f49-\\u0f69\\u0f71-\\u0f84\\u0f86-\\u0f8b\\u0f90-\\u0f95\\u0f97\\u0f99-\\u0fad\\u0fb1-\\u0fb7\\u0fb9\\u10a0-\\u10c5\\u10d0-\\u10f6\\u1e00-\\u1e9b\\u1ea0-\\u1ef9\\u1f00-\\u1f15\\u1f18-\\u1f1d\\u1f20-\\u1f45\\u1f48-\\u1f4d\\u1f50-\\u1f57\\u1f59\\u1f5b\\u1f5d\\u1f5f-\\u1f7d\\u1f80-\\u1fb4\\u1fb6-\\u1fbc\\u1fbe\\u1fc2-\\u1fc4\\u1fc6-\\u1fcc\\u1fd0-\\u1fd3\\u1fd6-\\u1fdb\\u1fe0-\\u1fec\\u1ff2-\\u1ff4\\u1ff6-\\u1ffc\\u203f-\\u2040\\u207f\\u2102\\u2107\\u210a-\\u2113\\u2115\\u2118-\\u211d\\u2124\\u2126\\u2128\\u212a-\\u2131\\u2133-\\u2138\\u2160-\\u2182\\u3005-\\u3007\\u3021-\\u3029\\u3041-\\u3093\\u309b-\\u309c\\u30a1-\\u30f6\\u30fb-\\u30fc\\u3105-\\u312c\\u4e00-\\u9fa5\\uac00-\\ud7a3]"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "0"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "1"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "2"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "3"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "4"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "5"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "6"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "7"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "8"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "9"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "type": "BLANK"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": ";"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\r"
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "\n"
+                                },
+                                {
+                                  "type": "BLANK"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\n"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": " "
+                        },
+                        {
+                          "type": "STRING",
+                          "value": " "
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\u0000"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "\u001a"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "c"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "w"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "d"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "hex_string": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "x\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "0"
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "1"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "2"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "3"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "4"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "5"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "6"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "7"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "8"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "9"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "a"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "b"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "c"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "d"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "e"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "f"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "A"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "B"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "C"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "D"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "E"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "F"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": " "
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\t"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\u000b"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\f"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\r"
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "\n"
+                                },
+                                {
+                                  "type": "BLANK"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\n"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": " "
+                        },
+                        {
+                          "type": "STRING",
+                          "value": " "
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\u0000"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "\u001a"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "c"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "w"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "d"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "token_string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "q{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "token_string_tokens"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "token_string_tokens": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_maybe_token_string_token"
+      }
+    },
+    "_maybe_token_string_token": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "token_no_braces"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "token_string_token"
+        }
+      ]
+    },
+    "token_string_token": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "token_string_tokens"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "character_literal": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "'"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[^'\\\\]"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\\'"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\\""
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\?"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\\\"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\0"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\a"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\b"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\f"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\n"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\r"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\t"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\v"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\x"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "\\u"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\U"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "a"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "b"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "c"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "d"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "e"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "f"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "A"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "B"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "C"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "D"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "E"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "F"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "a"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "b"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "c"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "d"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "e"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "f"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "A"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "B"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "C"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "D"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "E"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "F"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "a"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "b"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "c"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "d"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "e"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "f"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "A"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "B"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "C"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "D"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "E"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "F"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "a"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "b"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "c"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "d"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "e"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "f"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "A"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "B"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "C"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "D"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "E"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "F"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "a"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "b"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "c"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "d"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "e"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "f"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "A"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "B"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "C"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "D"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "E"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "F"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "a"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "b"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "c"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "d"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "e"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "f"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "A"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "B"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "C"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "D"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "E"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "F"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "1"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "2"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "3"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "4"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "5"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "6"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "7"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "8"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "9"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "a"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "b"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "c"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "d"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "f"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "A"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "B"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "C"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "D"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "F"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "1"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "2"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "3"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "4"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "5"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "6"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "7"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "8"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "9"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "a"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "b"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "c"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "d"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "f"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "A"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "B"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "C"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "D"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "F"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "1"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "2"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "3"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "4"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "5"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "6"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "7"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "&"
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "_"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[A-Za-z]"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[\\u00aa\\u00b5\\u00b7\\u00ba\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u01f5\\u01fa-\\u0217\\u0250-\\u02a8\\u02b0-\\u02b8\\u02bb\\u02bd-\\u02c1\\u02d0-\\u02d1\\u02e0-\\u02e4\\u037a\\u0386\\u0388-\\u038a\\u038c\\u038e-\\u03a1\\u03a3-\\u03ce\\u03d0-\\u03d6\\u03da\\u03dc\\u03de\\u03e0\\u03e2-\\u03f3\\u0401-\\u040c\\u040e-\\u044f\\u0451-\\u045c\\u045e-\\u0481\\u0490-\\u04c4\\u04c7-\\u04c8\\u04cb-\\u04cc\\u04d0-\\u04eb\\u04ee-\\u04f5\\u04f8-\\u04f9\\u0531-\\u0556\\u0559\\u0561-\\u0587\\u05b0-\\u05b9\\u05bb-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05d0-\\u05ea\\u05f0-\\u05f2\\u0621-\\u063a\\u0640-\\u0652\\u0660-\\u0669\\u0670-\\u06b7\\u06ba-\\u06be\\u06c0-\\u06ce\\u06d0-\\u06dc\\u06e5-\\u06e8\\u06ea-\\u06ed\\u06f0-\\u06f9\\u0901-\\u0903\\u0905-\\u0939\\u093d-\\u094d\\u0950-\\u0952\\u0958-\\u0963\\u0966-\\u096f\\u0981-\\u0983\\u0985-\\u098c\\u098f-\\u0990\\u0993-\\u09a8\\u09aa-\\u09b0\\u09b2\\u09b6-\\u09b9\\u09be-\\u09c4\\u09c7-\\u09c8\\u09cb-\\u09cd\\u09dc-\\u09dd\\u09df-\\u09e3\\u09e6-\\u09f1\\u0a02\\u0a05-\\u0a0a\\u0a0f-\\u0a10\\u0a13-\\u0a28\\u0a2a-\\u0a30\\u0a32-\\u0a33\\u0a35-\\u0a36\\u0a38-\\u0a39\\u0a3e-\\u0a42\\u0a47-\\u0a48\\u0a4b-\\u0a4d\\u0a59-\\u0a5c\\u0a5e\\u0a66-\\u0a6f\\u0a74\\u0a81-\\u0a83\\u0a85-\\u0a8b\\u0a8d\\u0a8f-\\u0a91\\u0a93-\\u0aa8\\u0aaa-\\u0ab0\\u0ab2-\\u0ab3\\u0ab5-\\u0ab9\\u0abd-\\u0ac5\\u0ac7-\\u0ac9\\u0acb-\\u0acd\\u0ad0\\u0ae0\\u0ae6-\\u0aef\\u0b01-\\u0b03\\u0b05-\\u0b0c\\u0b0f-\\u0b10\\u0b13-\\u0b28\\u0b2a-\\u0b30\\u0b32-\\u0b33\\u0b36-\\u0b39\\u0b3d-\\u0b43\\u0b47-\\u0b48\\u0b4b-\\u0b4d\\u0b5c-\\u0b5d\\u0b5f-\\u0b61\\u0b66-\\u0b6f\\u0b82-\\u0b83\\u0b85-\\u0b8a\\u0b8e-\\u0b90\\u0b92-\\u0b95\\u0b99-\\u0b9a\\u0b9c\\u0b9e-\\u0b9f\\u0ba3-\\u0ba4\\u0ba8-\\u0baa\\u0bae-\\u0bb5\\u0bb7-\\u0bb9\\u0bbe-\\u0bc2\\u0bc6-\\u0bc8\\u0bca-\\u0bcd\\u0be7-\\u0bef\\u0c01-\\u0c03\\u0c05-\\u0c0c\\u0c0e-\\u0c10\\u0c12-\\u0c28\\u0c2a-\\u0c33\\u0c35-\\u0c39\\u0c3e-\\u0c44\\u0c46-\\u0c48\\u0c4a-\\u0c4d\\u0c60-\\u0c61\\u0c66-\\u0c6f\\u0c82-\\u0c83\\u0c85-\\u0c8c\\u0c8e-\\u0c90\\u0c92-\\u0ca8\\u0caa-\\u0cb3\\u0cb5-\\u0cb9\\u0cbe-\\u0cc4\\u0cc6-\\u0cc8\\u0cca-\\u0ccd\\u0cde\\u0ce0-\\u0ce1\\u0ce6-\\u0cef\\u0d02-\\u0d03\\u0d05-\\u0d0c\\u0d0e-\\u0d10\\u0d12-\\u0d28\\u0d2a-\\u0d39\\u0d3e-\\u0d43\\u0d46-\\u0d48\\u0d4a-\\u0d4d\\u0d60-\\u0d61\\u0d66-\\u0d6f\\u0e01-\\u0e3a\\u0e40-\\u0e5b\\u0e81-\\u0e82\\u0e84\\u0e87-\\u0e88\\u0e8a\\u0e8d\\u0e94-\\u0e97\\u0e99-\\u0e9f\\u0ea1-\\u0ea3\\u0ea5\\u0ea7\\u0eaa-\\u0eab\\u0ead-\\u0eae\\u0eb0-\\u0eb9\\u0ebb-\\u0ebd\\u0ec0-\\u0ec4\\u0ec6\\u0ec8-\\u0ecd\\u0ed0-\\u0ed9\\u0edc-\\u0edd\\u0f00\\u0f18-\\u0f19\\u0f20-\\u0f33\\u0f35\\u0f37\\u0f39\\u0f3e-\\u0f47\\u0f49-\\u0f69\\u0f71-\\u0f84\\u0f86-\\u0f8b\\u0f90-\\u0f95\\u0f97\\u0f99-\\u0fad\\u0fb1-\\u0fb7\\u0fb9\\u10a0-\\u10c5\\u10d0-\\u10f6\\u1e00-\\u1e9b\\u1ea0-\\u1ef9\\u1f00-\\u1f15\\u1f18-\\u1f1d\\u1f20-\\u1f45\\u1f48-\\u1f4d\\u1f50-\\u1f57\\u1f59\\u1f5b\\u1f5d\\u1f5f-\\u1f7d\\u1f80-\\u1fb4\\u1fb6-\\u1fbc\\u1fbe\\u1fc2-\\u1fc4\\u1fc6-\\u1fcc\\u1fd0-\\u1fd3\\u1fd6-\\u1fdb\\u1fe0-\\u1fec\\u1ff2-\\u1ff4\\u1ff6-\\u1ffc\\u203f-\\u2040\\u207f\\u2102\\u2107\\u210a-\\u2113\\u2115\\u2118-\\u211d\\u2124\\u2126\\u2128\\u212a-\\u2131\\u2133-\\u2138\\u2160-\\u2182\\u3005-\\u3007\\u3021-\\u3029\\u3041-\\u3093\\u309b-\\u309c\\u30a1-\\u30f6\\u30fb-\\u30fc\\u3105-\\u312c\\u4e00-\\u9fa5\\uac00-\\ud7a3]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                },
+                                                {
+                                                  "type": "PATTERN",
+                                                  "value": "[A-Za-z]"
+                                                },
+                                                {
+                                                  "type": "PATTERN",
+                                                  "value": "[\\u00aa\\u00b5\\u00b7\\u00ba\\u00c0-\\u00d6\\u00d8-\\u00f6\\u00f8-\\u01f5\\u01fa-\\u0217\\u0250-\\u02a8\\u02b0-\\u02b8\\u02bb\\u02bd-\\u02c1\\u02d0-\\u02d1\\u02e0-\\u02e4\\u037a\\u0386\\u0388-\\u038a\\u038c\\u038e-\\u03a1\\u03a3-\\u03ce\\u03d0-\\u03d6\\u03da\\u03dc\\u03de\\u03e0\\u03e2-\\u03f3\\u0401-\\u040c\\u040e-\\u044f\\u0451-\\u045c\\u045e-\\u0481\\u0490-\\u04c4\\u04c7-\\u04c8\\u04cb-\\u04cc\\u04d0-\\u04eb\\u04ee-\\u04f5\\u04f8-\\u04f9\\u0531-\\u0556\\u0559\\u0561-\\u0587\\u05b0-\\u05b9\\u05bb-\\u05bd\\u05bf\\u05c1-\\u05c2\\u05d0-\\u05ea\\u05f0-\\u05f2\\u0621-\\u063a\\u0640-\\u0652\\u0660-\\u0669\\u0670-\\u06b7\\u06ba-\\u06be\\u06c0-\\u06ce\\u06d0-\\u06dc\\u06e5-\\u06e8\\u06ea-\\u06ed\\u06f0-\\u06f9\\u0901-\\u0903\\u0905-\\u0939\\u093d-\\u094d\\u0950-\\u0952\\u0958-\\u0963\\u0966-\\u096f\\u0981-\\u0983\\u0985-\\u098c\\u098f-\\u0990\\u0993-\\u09a8\\u09aa-\\u09b0\\u09b2\\u09b6-\\u09b9\\u09be-\\u09c4\\u09c7-\\u09c8\\u09cb-\\u09cd\\u09dc-\\u09dd\\u09df-\\u09e3\\u09e6-\\u09f1\\u0a02\\u0a05-\\u0a0a\\u0a0f-\\u0a10\\u0a13-\\u0a28\\u0a2a-\\u0a30\\u0a32-\\u0a33\\u0a35-\\u0a36\\u0a38-\\u0a39\\u0a3e-\\u0a42\\u0a47-\\u0a48\\u0a4b-\\u0a4d\\u0a59-\\u0a5c\\u0a5e\\u0a66-\\u0a6f\\u0a74\\u0a81-\\u0a83\\u0a85-\\u0a8b\\u0a8d\\u0a8f-\\u0a91\\u0a93-\\u0aa8\\u0aaa-\\u0ab0\\u0ab2-\\u0ab3\\u0ab5-\\u0ab9\\u0abd-\\u0ac5\\u0ac7-\\u0ac9\\u0acb-\\u0acd\\u0ad0\\u0ae0\\u0ae6-\\u0aef\\u0b01-\\u0b03\\u0b05-\\u0b0c\\u0b0f-\\u0b10\\u0b13-\\u0b28\\u0b2a-\\u0b30\\u0b32-\\u0b33\\u0b36-\\u0b39\\u0b3d-\\u0b43\\u0b47-\\u0b48\\u0b4b-\\u0b4d\\u0b5c-\\u0b5d\\u0b5f-\\u0b61\\u0b66-\\u0b6f\\u0b82-\\u0b83\\u0b85-\\u0b8a\\u0b8e-\\u0b90\\u0b92-\\u0b95\\u0b99-\\u0b9a\\u0b9c\\u0b9e-\\u0b9f\\u0ba3-\\u0ba4\\u0ba8-\\u0baa\\u0bae-\\u0bb5\\u0bb7-\\u0bb9\\u0bbe-\\u0bc2\\u0bc6-\\u0bc8\\u0bca-\\u0bcd\\u0be7-\\u0bef\\u0c01-\\u0c03\\u0c05-\\u0c0c\\u0c0e-\\u0c10\\u0c12-\\u0c28\\u0c2a-\\u0c33\\u0c35-\\u0c39\\u0c3e-\\u0c44\\u0c46-\\u0c48\\u0c4a-\\u0c4d\\u0c60-\\u0c61\\u0c66-\\u0c6f\\u0c82-\\u0c83\\u0c85-\\u0c8c\\u0c8e-\\u0c90\\u0c92-\\u0ca8\\u0caa-\\u0cb3\\u0cb5-\\u0cb9\\u0cbe-\\u0cc4\\u0cc6-\\u0cc8\\u0cca-\\u0ccd\\u0cde\\u0ce0-\\u0ce1\\u0ce6-\\u0cef\\u0d02-\\u0d03\\u0d05-\\u0d0c\\u0d0e-\\u0d10\\u0d12-\\u0d28\\u0d2a-\\u0d39\\u0d3e-\\u0d43\\u0d46-\\u0d48\\u0d4a-\\u0d4d\\u0d60-\\u0d61\\u0d66-\\u0d6f\\u0e01-\\u0e3a\\u0e40-\\u0e5b\\u0e81-\\u0e82\\u0e84\\u0e87-\\u0e88\\u0e8a\\u0e8d\\u0e94-\\u0e97\\u0e99-\\u0e9f\\u0ea1-\\u0ea3\\u0ea5\\u0ea7\\u0eaa-\\u0eab\\u0ead-\\u0eae\\u0eb0-\\u0eb9\\u0ebb-\\u0ebd\\u0ec0-\\u0ec4\\u0ec6\\u0ec8-\\u0ecd\\u0ed0-\\u0ed9\\u0edc-\\u0edd\\u0f00\\u0f18-\\u0f19\\u0f20-\\u0f33\\u0f35\\u0f37\\u0f39\\u0f3e-\\u0f47\\u0f49-\\u0f69\\u0f71-\\u0f84\\u0f86-\\u0f8b\\u0f90-\\u0f95\\u0f97\\u0f99-\\u0fad\\u0fb1-\\u0fb7\\u0fb9\\u10a0-\\u10c5\\u10d0-\\u10f6\\u1e00-\\u1e9b\\u1ea0-\\u1ef9\\u1f00-\\u1f15\\u1f18-\\u1f1d\\u1f20-\\u1f45\\u1f48-\\u1f4d\\u1f50-\\u1f57\\u1f59\\u1f5b\\u1f5d\\u1f5f-\\u1f7d\\u1f80-\\u1fb4\\u1fb6-\\u1fbc\\u1fbe\\u1fc2-\\u1fc4\\u1fc6-\\u1fcc\\u1fd0-\\u1fd3\\u1fd6-\\u1fdb\\u1fe0-\\u1fec\\u1ff2-\\u1ff4\\u1ff6-\\u1ffc\\u203f-\\u2040\\u207f\\u2102\\u2107\\u210a-\\u2113\\u2115\\u2118-\\u211d\\u2124\\u2126\\u2128\\u212a-\\u2131\\u2133-\\u2138\\u2160-\\u2182\\u3005-\\u3007\\u3021-\\u3029\\u3041-\\u3093\\u309b-\\u309c\\u30a1-\\u30f6\\u30fb-\\u30fc\\u3105-\\u312c\\u4e00-\\u9fa5\\uac00-\\ud7a3]"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "0"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "8"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "9"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ";"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "'"
+          }
+        ]
+      }
+    },
+    "integer_literal": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "1"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "2"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "3"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "4"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "5"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "6"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "7"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "8"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "9"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "0"
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "1"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "2"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "3"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "4"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "5"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "6"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "7"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "8"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "9"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "0b"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "0B"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "0"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "1"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "1"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "0"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "1"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "0x"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "0X"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "1"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "2"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "3"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "4"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "5"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "6"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "7"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "8"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "9"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "a"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "b"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "c"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "d"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "f"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "A"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "B"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "C"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "D"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "E"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "F"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "0"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "8"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "9"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "a"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "b"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "c"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "d"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "e"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "f"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "A"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "B"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "C"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "D"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "E"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "F"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "0"
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "1"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "2"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "3"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "4"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "5"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "6"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "7"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "8"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "9"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "a"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "b"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "c"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "d"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "e"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "f"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "A"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "B"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "C"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "D"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "E"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "F"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "1"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "2"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "3"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "4"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "5"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "6"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "7"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "8"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "9"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "a"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "b"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "c"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "d"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "f"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "A"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "B"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "C"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "D"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "E"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "F"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "L"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "u"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "U"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "Lu"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "LU"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "uL"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "UL"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "float_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_float_literal_no_trailing_period"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_float_literal_trailing_period"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "integer_literal"
+                  },
+                  "named": false,
+                  "value": "_actually_a_float_literal_without_its_trailing_period"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            }
+          ]
+        }
+      ]
+    },
+    "_float_literal_no_trailing_period": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "0"
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "1"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "2"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "3"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "4"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "5"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "6"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "7"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "8"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "9"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "_"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "."
+                          },
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "0"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "1"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "2"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "3"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "4"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "5"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "6"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "7"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "8"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "9"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "0"
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "1"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "2"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "3"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "4"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "5"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "6"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "7"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "8"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "9"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "."
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "."
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "0"
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "1"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "2"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "3"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "4"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "5"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "6"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "7"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "8"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "9"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "_"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "0"
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "1"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "2"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "3"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "4"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "5"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "6"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "7"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "8"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "9"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "_"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "0"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "1"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "2"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "3"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "4"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "5"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "6"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "7"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "8"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "9"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "0"
+                                                            },
+                                                            {
+                                                              "type": "CHOICE",
+                                                              "members": [
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "1"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "2"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "3"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "4"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "5"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "6"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "7"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "8"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "9"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "_"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "0"
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "1"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "2"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "3"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "4"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "5"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "6"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "7"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "8"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "9"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "_"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "0"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "1"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "2"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "3"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "4"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "5"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "6"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "7"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "8"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "9"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "E"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "e+"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "E+"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "e-"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "E-"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "0"
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "1"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "2"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "3"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "4"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "5"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "6"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "7"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "8"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "9"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "_"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "."
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "1"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "2"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "3"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "4"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "5"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "6"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "7"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "8"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "9"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "0"
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "1"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "2"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "3"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "4"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "5"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "6"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "7"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "8"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "9"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "_"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0x"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "0X"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "0"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "1"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "2"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "3"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "4"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "5"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "6"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "7"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "8"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "9"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "a"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "b"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "c"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "d"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "e"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "f"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "A"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "B"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "C"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "D"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "E"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "F"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "0"
+                                                            },
+                                                            {
+                                                              "type": "CHOICE",
+                                                              "members": [
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "1"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "2"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "3"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "4"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "5"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "6"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "7"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "8"
+                                                                },
+                                                                {
+                                                                  "type": "STRING",
+                                                                  "value": "9"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "a"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "b"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "c"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "d"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "e"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "f"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "A"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "B"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "C"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "D"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "E"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "F"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "_"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "0"
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "1"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "2"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "3"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "4"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "5"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "6"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "7"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "8"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "9"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "a"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "b"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "c"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "d"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "e"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "f"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "A"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "B"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "C"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "D"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "E"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "F"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "0"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "1"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "2"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "3"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "4"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "5"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "6"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "7"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "8"
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "9"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "a"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "b"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "c"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "d"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "e"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "f"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "A"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "B"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "C"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "D"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "E"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "F"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "."
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "a"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "b"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "c"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "d"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "e"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "f"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "A"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "B"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "C"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "D"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "E"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "F"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "a"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "b"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "c"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "d"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "e"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "f"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "A"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "B"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "C"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "D"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "E"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "F"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "_"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "a"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "b"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "c"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "d"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "e"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "f"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "A"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "B"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "C"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "D"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "E"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "F"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "a"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "b"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "c"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "d"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "e"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "f"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "A"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "B"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "C"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "D"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "E"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "F"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "_"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "0"
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "1"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "2"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "3"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "4"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "5"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "6"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "7"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "8"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "9"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "a"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "b"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "c"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "d"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "e"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "f"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "A"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "B"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "C"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "D"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "E"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "F"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "_"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "0"
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "1"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "2"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "3"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "4"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "5"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "6"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "7"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "8"
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "9"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "a"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "b"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "c"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "d"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "e"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "f"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "A"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "B"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "C"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "D"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "E"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "F"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "p"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "P"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "p+"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "P+"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "p-"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "P-"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "0"
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "1"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "2"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "3"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "4"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "5"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "6"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "7"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "8"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "9"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "_"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "0"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "8"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "9"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "_"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "f"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "F"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "L"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "i"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "i"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "0"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "1"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "2"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "3"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "4"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "5"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "6"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "7"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "8"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "9"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "0"
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "1"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "2"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "3"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "4"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "5"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "6"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "7"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "8"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "9"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0b"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "0B"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "0"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "1"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "0"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "1"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "0"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "1"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0x"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "0X"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "a"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "b"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "c"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "d"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "e"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "f"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "A"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "B"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "C"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "D"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "E"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "F"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "0"
+                                                },
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "1"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "2"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "3"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "4"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "5"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "6"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "7"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "8"
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "9"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "a"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "b"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "c"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "d"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "e"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "f"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "A"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "B"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "C"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "D"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "E"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "F"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "_"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "0"
+                                            },
+                                            {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "1"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "2"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "3"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "4"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "5"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "6"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "7"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "8"
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "9"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "a"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "b"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "c"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "d"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "e"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "f"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "A"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "B"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "C"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "D"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "E"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "F"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "_"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "0"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "a"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "b"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "c"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "d"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "e"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "f"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "A"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "B"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "C"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "D"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "E"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "F"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "f"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "F"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "f"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "F"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "L"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "i"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_float_literal_trailing_period": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "1"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "2"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "3"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "4"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "5"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "6"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "7"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "8"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "9"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "0"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "0"
+                                                        },
+                                                        {
+                                                          "type": "CHOICE",
+                                                          "members": [
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "1"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "2"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "3"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "4"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "5"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "6"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "7"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "8"
+                                                            },
+                                                            {
+                                                              "type": "STRING",
+                                                              "value": "9"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "_"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "CHOICE",
+                                              "members": [
+                                                {
+                                                  "type": "CHOICE",
+                                                  "members": [
+                                                    {
+                                                      "type": "STRING",
+                                                      "value": "0"
+                                                    },
+                                                    {
+                                                      "type": "CHOICE",
+                                                      "members": [
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "1"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "2"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "3"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "4"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "5"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "6"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "7"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "8"
+                                                        },
+                                                        {
+                                                          "type": "STRING",
+                                                          "value": "9"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "STRING",
+                                                  "value": "_"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "0"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "1"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "2"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "3"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "4"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "5"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "6"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "7"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "8"
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "9"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "abstract"
+        },
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "STRING",
+          "value": "align"
+        },
+        {
+          "type": "STRING",
+          "value": "asm"
+        },
+        {
+          "type": "STRING",
+          "value": "assert"
+        },
+        {
+          "type": "STRING",
+          "value": "auto"
+        },
+        {
+          "type": "STRING",
+          "value": "body"
+        },
+        {
+          "type": "STRING",
+          "value": "bool"
+        },
+        {
+          "type": "STRING",
+          "value": "break"
+        },
+        {
+          "type": "STRING",
+          "value": "byte"
+        },
+        {
+          "type": "STRING",
+          "value": "case"
+        },
+        {
+          "type": "STRING",
+          "value": "cast"
+        },
+        {
+          "type": "STRING",
+          "value": "catch"
+        },
+        {
+          "type": "STRING",
+          "value": "cdouble"
+        },
+        {
+          "type": "STRING",
+          "value": "cent"
+        },
+        {
+          "type": "STRING",
+          "value": "cfloat"
+        },
+        {
+          "type": "STRING",
+          "value": "char"
+        },
+        {
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "continue"
+        },
+        {
+          "type": "STRING",
+          "value": "creal"
+        },
+        {
+          "type": "STRING",
+          "value": "dchar"
+        },
+        {
+          "type": "STRING",
+          "value": "debug"
+        },
+        {
+          "type": "STRING",
+          "value": "default"
+        },
+        {
+          "type": "STRING",
+          "value": "delegate"
+        },
+        {
+          "type": "STRING",
+          "value": "delete"
+        },
+        {
+          "type": "STRING",
+          "value": "deprecated"
+        },
+        {
+          "type": "STRING",
+          "value": "do"
+        },
+        {
+          "type": "STRING",
+          "value": "double"
+        },
+        {
+          "type": "STRING",
+          "value": "else"
+        },
+        {
+          "type": "STRING",
+          "value": "enum"
+        },
+        {
+          "type": "STRING",
+          "value": "export"
+        },
+        {
+          "type": "STRING",
+          "value": "extern"
+        },
+        {
+          "type": "STRING",
+          "value": "false"
+        },
+        {
+          "type": "STRING",
+          "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "finally"
+        },
+        {
+          "type": "STRING",
+          "value": "float"
+        },
+        {
+          "type": "STRING",
+          "value": "for"
+        },
+        {
+          "type": "STRING",
+          "value": "foreach"
+        },
+        {
+          "type": "STRING",
+          "value": "foreach_reverse"
+        },
+        {
+          "type": "STRING",
+          "value": "function"
+        },
+        {
+          "type": "STRING",
+          "value": "goto"
+        },
+        {
+          "type": "STRING",
+          "value": "idouble"
+        },
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "STRING",
+          "value": "ifloat"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "import"
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "int"
+        },
+        {
+          "type": "STRING",
+          "value": "interface"
+        },
+        {
+          "type": "STRING",
+          "value": "invariant"
+        },
+        {
+          "type": "STRING",
+          "value": "ireal"
+        },
+        {
+          "type": "STRING",
+          "value": "is"
+        },
+        {
+          "type": "STRING",
+          "value": "lazy"
+        },
+        {
+          "type": "STRING",
+          "value": "long"
+        },
+        {
+          "type": "STRING",
+          "value": "macro"
+        },
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "STRING",
+          "value": "module"
+        },
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "STRING",
+          "value": "nothrow"
+        },
+        {
+          "type": "STRING",
+          "value": "null"
+        },
+        {
+          "type": "STRING",
+          "value": "out"
+        },
+        {
+          "type": "STRING",
+          "value": "override"
+        },
+        {
+          "type": "STRING",
+          "value": "package"
+        },
+        {
+          "type": "STRING",
+          "value": "pragma"
+        },
+        {
+          "type": "STRING",
+          "value": "private"
+        },
+        {
+          "type": "STRING",
+          "value": "protected"
+        },
+        {
+          "type": "STRING",
+          "value": "public"
+        },
+        {
+          "type": "STRING",
+          "value": "pure"
+        },
+        {
+          "type": "STRING",
+          "value": "real"
+        },
+        {
+          "type": "STRING",
+          "value": "ref"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "STRING",
+          "value": "scope"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        },
+        {
+          "type": "STRING",
+          "value": "short"
+        },
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "struct"
+        },
+        {
+          "type": "STRING",
+          "value": "super"
+        },
+        {
+          "type": "STRING",
+          "value": "switch"
+        },
+        {
+          "type": "STRING",
+          "value": "synchronized"
+        },
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "throw"
+        },
+        {
+          "type": "STRING",
+          "value": "true"
+        },
+        {
+          "type": "STRING",
+          "value": "try"
+        },
+        {
+          "type": "STRING",
+          "value": "typeid"
+        },
+        {
+          "type": "STRING",
+          "value": "typeof"
+        },
+        {
+          "type": "STRING",
+          "value": "ubyte"
+        },
+        {
+          "type": "STRING",
+          "value": "ucent"
+        },
+        {
+          "type": "STRING",
+          "value": "uint"
+        },
+        {
+          "type": "STRING",
+          "value": "ulong"
+        },
+        {
+          "type": "STRING",
+          "value": "union"
+        },
+        {
+          "type": "STRING",
+          "value": "unittest"
+        },
+        {
+          "type": "STRING",
+          "value": "ushort"
+        },
+        {
+          "type": "STRING",
+          "value": "version"
+        },
+        {
+          "type": "STRING",
+          "value": "void"
+        },
+        {
+          "type": "STRING",
+          "value": "wchar"
+        },
+        {
+          "type": "STRING",
+          "value": "while"
+        },
+        {
+          "type": "STRING",
+          "value": "with"
+        },
+        {
+          "type": "STRING",
+          "value": "__FILE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__FILE_FULL_PATH__"
+        },
+        {
+          "type": "STRING",
+          "value": "__MODULE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__LINE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__FUNCTION__"
+        },
+        {
+          "type": "STRING",
+          "value": "__PRETTY_FUNCTION__"
+        },
+        {
+          "type": "STRING",
+          "value": "__gshared"
+        },
+        {
+          "type": "STRING",
+          "value": "__traits"
+        },
+        {
+          "type": "STRING",
+          "value": "__vector"
+        },
+        {
+          "type": "STRING",
+          "value": "__parameters"
+        }
+      ]
+    },
+    "special_token_sequence": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#"
+        },
+        {
+          "type": "STRING",
+          "value": "line"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "integer_literal"
+            },
+            {
+              "type": "STRING",
+              "value": "__LINE__"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "filespec"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_line"
+        }
+      ]
+    },
+    "filespec": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\""
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\"]"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "\""
+          }
+        ]
+      }
+    },
+    "module": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "module_declaration"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "decl_defs"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "decl_defs"
+        }
+      ]
+    },
+    "decl_defs": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_decl_def"
+      }
+    },
+    "_decl_def": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "attribute_specifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_constructor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "destructor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "postblit"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "allocator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "deallocator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "invariant"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unit_test"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alias_this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_constructor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_destructor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "shared_static_constructor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "shared_static_destructor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "debug_specification"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "version_specification"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_assert"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_mixin_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_mixin"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mixin_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "empty_declaration"
+        }
+      ]
+    },
+    "empty_declaration": {
+      "type": "STRING",
+      "value": ";"
+    },
+    "module_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "module_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "module"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_module_fully_qualified_name"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "module_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_module_attribute"
+      }
+    },
+    "_module_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "deprecated_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "user_defined_attribute"
+        }
+      ]
+    },
+    "_maybe_module_fully_qualified_name": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "module_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "module_fully_qualified_name"
+        }
+      ]
+    },
+    "module_fully_qualified_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "packages"
+        },
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "module_name"
+        }
+      ]
+    },
+    "module_name": {
+      "type": "SYMBOL",
+      "name": "identifier"
+    },
+    "packages": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "package_name"
+              },
+              {
+                "type": "STRING",
+                "value": "."
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "package_name"
+        }
+      ]
+    },
+    "package_name": {
+      "type": "SYMBOL",
+      "name": "identifier"
+    },
+    "import_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "static"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "import"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_list"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "import_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "import"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "import"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "import_bindings"
+            }
+          ]
+        }
+      ]
+    },
+    "import": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "module_alias_identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_module_fully_qualified_name"
+        }
+      ]
+    },
+    "import_bindings": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "import"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_bind_list"
+        }
+      ]
+    },
+    "import_bind_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "import_bind"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_bind"
+        }
+      ]
+    },
+    "import_bind": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "module_alias_identifier": {
+      "type": "SYMBOL",
+      "name": "identifier"
+    },
+    "mixin_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_func_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_var_declarations"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alias_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alias_assign"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_aggregate_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_enum_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_foreach_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_assert"
+        }
+      ]
+    },
+    "_maybe_var_declarations": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "auto_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "var_declarations"
+        }
+      ]
+    },
+    "var_declarations": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "storage_classes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_basic_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "declarators"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "declarators": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_declarator_initializer"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "declarator_identifier_list"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_maybe_declarator_initializer": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "var_declarator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alt_declarator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "declarator_initializer"
+        }
+      ]
+    },
+    "declarator_initializer": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "var_declarator"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "template_parameters"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "alt_declarator"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_initializer"
+        }
+      ]
+    },
+    "declarator_identifier_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_declarator_identifier"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_declarator_identifier"
+        }
+      ]
+    },
+    "_declarator_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "var_declarator_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alt_declarator_identifier"
+        }
+      ]
+    },
+    "var_declarator_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "template_parameters"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_initializer"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "alt_declarator_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_suffixes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "alt_declarator_suffixes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_initializer"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_declarator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "var_declarator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alt_declarator"
+        }
+      ]
+    },
+    "var_declarator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_suffixes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "alt_declarator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_suffixes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "alt_declarator_suffixes"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "alt_declarator_inner"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "alt_func_declarator_suffix"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "alt_declarator_suffixes"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "alt_declarator_inner": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_suffixes"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "alt_func_declarator_suffix"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alt_declarator"
+        }
+      ]
+    },
+    "alt_declarator_suffixes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "alt_declarator_suffix"
+      }
+    },
+    "alt_declarator_suffix": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "alt_func_declarator_suffix": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "storage_classes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_maybe_storage_class"
+      }
+    },
+    "_maybe_storage_class": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "linkage_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "align_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_at_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "property"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "storage_class"
+        }
+      ]
+    },
+    "storage_class": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "deprecated"
+        },
+        {
+          "type": "STRING",
+          "value": "enum"
+        },
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "extern"
+        },
+        {
+          "type": "STRING",
+          "value": "abstract"
+        },
+        {
+          "type": "STRING",
+          "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "override"
+        },
+        {
+          "type": "STRING",
+          "value": "synchronized"
+        },
+        {
+          "type": "STRING",
+          "value": "auto"
+        },
+        {
+          "type": "STRING",
+          "value": "scope"
+        },
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        },
+        {
+          "type": "STRING",
+          "value": "__gshared"
+        },
+        {
+          "type": "STRING",
+          "value": "nothrow"
+        },
+        {
+          "type": "STRING",
+          "value": "pure"
+        },
+        {
+          "type": "STRING",
+          "value": "ref"
+        }
+      ]
+    },
+    "_initializer": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "void_initializer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_void_initializer"
+        }
+      ]
+    },
+    "_non_void_initializer": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "exp_initializer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_initializer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "struct_initializer"
+        }
+      ]
+    },
+    "exp_initializer": {
+      "type": "SYMBOL",
+      "name": "_maybe_assign_expression"
+    },
+    "array_initializer": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "array_member_initializations"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "array_member_initializations": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "array_member_initialization"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_member_initialization"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "array_member_initialization": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                },
+                {
+                  "type": "STRING",
+                  "value": ":"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_void_initializer"
+        }
+      ]
+    },
+    "struct_initializer": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "struct_member_initializers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "struct_member_initializers": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "struct_member_initializer"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "struct_member_initializer"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "struct_member_initializer": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": ":"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_void_initializer"
+        }
+      ]
+    },
+    "auto_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "storage_classes"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "auto_assignments"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "auto_assignments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "auto_assignment"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "auto_assignment"
+        }
+      ]
+    },
+    "auto_assignment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_parameters"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_initializer"
+        }
+      ]
+    },
+    "alias_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "storage_classes"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_basic_type"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "declarators"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "func_declarator"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "alias_assignments"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "alias_assignments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "alias_assignment"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alias_assignment"
+        }
+      ]
+    },
+    "alias_assignment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_parameters"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "storage_classes"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_maybe_basic_type"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "parameters"
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "member_function_attributes"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_function_literal"
+            }
+          ]
+        }
+      ]
+    },
+    "alias_assign": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "void_initializer": {
+      "type": "STRING",
+      "value": "void"
+    },
+    "type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_ctors"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_basic_type"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_suffixes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "type_ctors": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "type_ctor"
+      }
+    },
+    "type_ctor": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        }
+      ]
+    },
+    "_maybe_basic_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "fundamental_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "qualified_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "typeof"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "vector"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "traits_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mixin_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "basic_type"
+        }
+      ]
+    },
+    "basic_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "typeof"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "qualified_identifier"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_ctor"
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "vector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__vector"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "vector_base_type"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "vector_base_type": {
+      "type": "SYMBOL",
+      "name": "type"
+    },
+    "fundamental_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "bool"
+        },
+        {
+          "type": "STRING",
+          "value": "byte"
+        },
+        {
+          "type": "STRING",
+          "value": "ubyte"
+        },
+        {
+          "type": "STRING",
+          "value": "short"
+        },
+        {
+          "type": "STRING",
+          "value": "ushort"
+        },
+        {
+          "type": "STRING",
+          "value": "int"
+        },
+        {
+          "type": "STRING",
+          "value": "uint"
+        },
+        {
+          "type": "STRING",
+          "value": "long"
+        },
+        {
+          "type": "STRING",
+          "value": "ulong"
+        },
+        {
+          "type": "STRING",
+          "value": "cent"
+        },
+        {
+          "type": "STRING",
+          "value": "ucent"
+        },
+        {
+          "type": "STRING",
+          "value": "char"
+        },
+        {
+          "type": "STRING",
+          "value": "wchar"
+        },
+        {
+          "type": "STRING",
+          "value": "dchar"
+        },
+        {
+          "type": "STRING",
+          "value": "float"
+        },
+        {
+          "type": "STRING",
+          "value": "double"
+        },
+        {
+          "type": "STRING",
+          "value": "real"
+        },
+        {
+          "type": "STRING",
+          "value": "ifloat"
+        },
+        {
+          "type": "STRING",
+          "value": "idouble"
+        },
+        {
+          "type": "STRING",
+          "value": "ireal"
+        },
+        {
+          "type": "STRING",
+          "value": "cfloat"
+        },
+        {
+          "type": "STRING",
+          "value": "cdouble"
+        },
+        {
+          "type": "STRING",
+          "value": "creal"
+        },
+        {
+          "type": "STRING",
+          "value": "void"
+        }
+      ]
+    },
+    "type_suffixes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "type_suffix"
+      }
+    },
+    "type_suffix": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_maybe_assign_expression"
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": ".."
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_maybe_assign_expression"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "type"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "delegate"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parameters"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "member_function_attributes"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parameters"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "function_attributes"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "qualified_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "["
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_maybe_assign_expression"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "]"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "template_instance"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "."
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "qualified_identifier"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "typeof": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "typeof"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "STRING",
+              "value": "return"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "mixin_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "attribute_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_attribute"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_declaration_block"
+            }
+          ]
+        }
+      ]
+    },
+    "_maybe_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "linkage_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "align_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "deprecated_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "visibility_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pragma"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_at_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_attribute_kwd"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "attribute"
+        }
+      ]
+    },
+    "attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "extern"
+        },
+        {
+          "type": "STRING",
+          "value": "abstract"
+        },
+        {
+          "type": "STRING",
+          "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "override"
+        },
+        {
+          "type": "STRING",
+          "value": "synchronized"
+        },
+        {
+          "type": "STRING",
+          "value": "auto"
+        },
+        {
+          "type": "STRING",
+          "value": "scope"
+        },
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        },
+        {
+          "type": "STRING",
+          "value": "__gshared"
+        },
+        {
+          "type": "STRING",
+          "value": "ref"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        }
+      ]
+    },
+    "function_attribute_kwd": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "nothrow"
+        },
+        {
+          "type": "STRING",
+          "value": "pure"
+        }
+      ]
+    },
+    "_maybe_at_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "property"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "user_defined_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "at_attribute"
+        }
+      ]
+    },
+    "at_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "disable"
+            },
+            {
+              "type": "STRING",
+              "value": "nogc"
+            },
+            {
+              "type": "STRING",
+              "value": "live"
+            },
+            {
+              "type": "STRING",
+              "value": "safe"
+            },
+            {
+              "type": "STRING",
+              "value": "system"
+            },
+            {
+              "type": "STRING",
+              "value": "trusted"
+            }
+          ]
+        }
+      ]
+    },
+    "property": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "STRING",
+          "value": "property"
+        }
+      ]
+    },
+    "_maybe_declaration_block": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_decl_def"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "declaration_block"
+        }
+      ]
+    },
+    "declaration_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "decl_defs"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "linkage_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "extern"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "linkage_type"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "C++"
+                },
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "qualified_identifier"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "namespace_list"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "linkage_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "C"
+        },
+        {
+          "type": "STRING",
+          "value": "C++"
+        },
+        {
+          "type": "STRING",
+          "value": "D"
+        },
+        {
+          "type": "STRING",
+          "value": "Windows"
+        },
+        {
+          "type": "STRING",
+          "value": "System"
+        },
+        {
+          "type": "STRING",
+          "value": "Objective-C"
+        }
+      ]
+    },
+    "namespace_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_maybe_conditional_expression"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_conditional_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "align_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "align"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "deprecated_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "deprecated"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "visibility_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "private"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "package"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "qualified_identifier"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "protected"
+        },
+        {
+          "type": "STRING",
+          "value": "public"
+        },
+        {
+          "type": "STRING",
+          "value": "export"
+        }
+      ]
+    },
+    "user_defined_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "argument_list"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "template_instance"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "argument_list"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "pragma_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "pragma"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_no_scope_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "pragma": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "pragma"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "argument_list"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "expression": {
+      "type": "SYMBOL",
+      "name": "_maybe_comma_expression"
+    },
+    "_maybe_comma_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comma_expression"
+        }
+      ]
+    },
+    "comma_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_comma_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        }
+      ]
+    },
+    "_maybe_assign_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_conditional_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assign_expression"
+        }
+      ]
+    },
+    "assign_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_conditional_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "STRING",
+              "value": "+="
+            },
+            {
+              "type": "STRING",
+              "value": "-="
+            },
+            {
+              "type": "STRING",
+              "value": "*="
+            },
+            {
+              "type": "STRING",
+              "value": "/="
+            },
+            {
+              "type": "STRING",
+              "value": "%="
+            },
+            {
+              "type": "STRING",
+              "value": "&="
+            },
+            {
+              "type": "STRING",
+              "value": "|="
+            },
+            {
+              "type": "STRING",
+              "value": "^="
+            },
+            {
+              "type": "STRING",
+              "value": "~="
+            },
+            {
+              "type": "STRING",
+              "value": "<<="
+            },
+            {
+              "type": "STRING",
+              "value": ">>="
+            },
+            {
+              "type": "STRING",
+              "value": ">>>="
+            },
+            {
+              "type": "STRING",
+              "value": "^^="
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        }
+      ]
+    },
+    "_maybe_conditional_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_or_or_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_expression"
+        }
+      ]
+    },
+    "conditional_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_or_or_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "?"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_conditional_expression"
+        }
+      ]
+    },
+    "_maybe_or_or_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_and_and_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "or_or_expression"
+        }
+      ]
+    },
+    "or_or_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_or_or_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "||"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_and_and_expression"
+        }
+      ]
+    },
+    "_maybe_and_and_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_or_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "and_and_expression"
+        }
+      ]
+    },
+    "and_and_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_and_and_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "&&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_or_expression"
+        }
+      ]
+    },
+    "_maybe_or_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_xor_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "or_expression"
+        }
+      ]
+    },
+    "or_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_or_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_xor_expression"
+        }
+      ]
+    },
+    "_maybe_xor_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_and_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xor_expression"
+        }
+      ]
+    },
+    "xor_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_xor_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_and_expression"
+        }
+      ]
+    },
+    "_maybe_and_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_cmp_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "and_expression"
+        }
+      ]
+    },
+    "and_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_and_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_cmp_expression"
+        }
+      ]
+    },
+    "_cmp_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "equal_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identity_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rel_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "in_expression"
+        }
+      ]
+    },
+    "equal_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=="
+            },
+            {
+              "type": "STRING",
+              "value": "!="
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        }
+      ]
+    },
+    "identity_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "!"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "is"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        }
+      ]
+    },
+    "rel_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "STRING",
+              "value": "<="
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            },
+            {
+              "type": "STRING",
+              "value": ">="
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        }
+      ]
+    },
+    "in_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "!"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        }
+      ]
+    },
+    "_maybe_shift_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_add_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "shift_expression"
+        }
+      ]
+    },
+    "shift_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_shift_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<<"
+            },
+            {
+              "type": "STRING",
+              "value": ">>"
+            },
+            {
+              "type": "STRING",
+              "value": ">>>"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_add_expression"
+        }
+      ]
+    },
+    "_maybe_add_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_mul_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cat_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "add_expression"
+        }
+      ]
+    },
+    "add_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_add_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "+"
+            },
+            {
+              "type": "STRING",
+              "value": "-"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_mul_expression"
+        }
+      ]
+    },
+    "cat_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_add_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_mul_expression"
+        }
+      ]
+    },
+    "_maybe_mul_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mul_expression"
+        }
+      ]
+    },
+    "mul_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_mul_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "STRING",
+              "value": "/"
+            },
+            {
+              "type": "STRING",
+              "value": "%"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        }
+      ]
+    },
+    "_maybe_unary_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "complement_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "delete_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cast_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_pow_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unary_expression"
+        }
+      ]
+    },
+    "unary_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&"
+            },
+            {
+              "type": "STRING",
+              "value": "++"
+            },
+            {
+              "type": "STRING",
+              "value": "--"
+            },
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "STRING",
+              "value": "-"
+            },
+            {
+              "type": "STRING",
+              "value": "+"
+            },
+            {
+              "type": "STRING",
+              "value": "!"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        }
+      ]
+    },
+    "complement_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        }
+      ]
+    },
+    "_maybe_new_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "new_anon_class_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "new_expression"
+        }
+      ]
+    },
+    "new_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "allocator_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "["
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_maybe_assign_expression"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "]"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "argument_list"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "allocator_arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_maybe_assign_expression"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "delete_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "delete"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        }
+      ]
+    },
+    "cast_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "cast"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_ctors"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        }
+      ]
+    },
+    "_maybe_pow_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_postfix_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pow_expression"
+        }
+      ]
+    },
+    "pow_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_postfix_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "^^"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_unary_expression"
+        }
+      ]
+    },
+    "_maybe_postfix_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "primary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "index_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "slice_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "postfix_expression"
+        }
+      ]
+    },
+    "postfix_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_postfix_expression"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "template_instance"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_maybe_new_expression"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "++"
+                },
+                {
+                  "type": "STRING",
+                  "value": "--"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_postfix_expression"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "type_ctors"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_maybe_basic_type"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "argument_list"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "index_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_postfix_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "slice_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_postfix_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "slice"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "slice": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ".."
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "slice"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "primary_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "("
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "type"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "template_instance"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "super"
+        },
+        {
+          "type": "STRING",
+          "value": "null"
+        },
+        {
+          "type": "STRING",
+          "value": "true"
+        },
+        {
+          "type": "STRING",
+          "value": "false"
+        },
+        {
+          "type": "STRING",
+          "value": "$"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "character_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_literals"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assoc_array_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_function_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assert_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mixin_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_new_expression"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "fundamental_type"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_ctor"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "type"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "argument_list"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "typeof"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "typeid_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "is_expression"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "special_keyword"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "traits_expression"
+        }
+      ]
+    },
+    "string_literals": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_string_literal"
+      }
+    },
+    "array_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "assoc_array_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "key_value_pairs"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "key_value_pairs": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "key_value_pair"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "key_value_pair"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "key_value_pair": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "key_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "value_expression"
+        }
+      ]
+    },
+    "key_expression": {
+      "type": "SYMBOL",
+      "name": "_maybe_assign_expression"
+    },
+    "value_expression": {
+      "type": "SYMBOL",
+      "name": "_maybe_assign_expression"
+    },
+    "_maybe_function_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "function_literal_body"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_literal"
+        }
+      ]
+    },
+    "function_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "function"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "ref"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "type"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "parameter_with_attributes"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "delegate"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "ref"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "type"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "parameter_with_member_attributes"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "ref"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "parameter_with_member_attributes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_function_literal_body2"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_assign_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "parameter_with_attributes": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "parameter_with_member_attributes": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_maybe_function_literal_body2": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "function_literal_body"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_literal_body2"
+        }
+      ]
+    },
+    "function_literal_body2": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        }
+      ]
+    },
+    "assert_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "assert"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assert_arguments"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "assert_arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "mixin_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "import_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "import"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "typeid_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "typeid"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "is_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "is"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ":"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "=="
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type_specialization"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "template_parameter_list"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "type_specialization": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "STRING",
+          "value": "struct"
+        },
+        {
+          "type": "STRING",
+          "value": "union"
+        },
+        {
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "STRING",
+          "value": "interface"
+        },
+        {
+          "type": "STRING",
+          "value": "enum"
+        },
+        {
+          "type": "STRING",
+          "value": "__vector"
+        },
+        {
+          "type": "STRING",
+          "value": "function"
+        },
+        {
+          "type": "STRING",
+          "value": "delegate"
+        },
+        {
+          "type": "STRING",
+          "value": "super"
+        },
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "STRING",
+          "value": "__parameters"
+        },
+        {
+          "type": "STRING",
+          "value": "module"
+        },
+        {
+          "type": "STRING",
+          "value": "package"
+        }
+      ]
+    },
+    "special_keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__FILE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__FILE_FULL_PATH__"
+        },
+        {
+          "type": "STRING",
+          "value": "__MODULE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__LINE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__FUNCTION__"
+        },
+        {
+          "type": "STRING",
+          "value": "__PRETTY_FUNCTION__"
+        }
+      ]
+    },
+    "_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "scope_block_statement"
+        }
+      ]
+    },
+    "empty_statement": {
+      "type": "STRING",
+      "value": ";"
+    },
+    "_no_scope_non_empty_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "_no_scope_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "_non_empty_or_scope_block_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "scope_block_statement"
+        }
+      ]
+    },
+    "_non_empty_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement_no_case_no_default"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case_range_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "default_statement"
+        }
+      ]
+    },
+    "_non_empty_statement_no_case_no_default": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "labeled_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "declaration_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "if_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "while_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "do_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "for_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "switch_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "final_switch_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "continue_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "break_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "return_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "goto_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "with_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "synchronized_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "try_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "scope_guard_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "throw_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mixin_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_range_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pragma_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_foreach_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_assert"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_mixin"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_declaration"
+        }
+      ]
+    },
+    "_scope_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "scope_block_statement": {
+      "type": "SYMBOL",
+      "name": "block_statement"
+    },
+    "labeled_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statement"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "block_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "statement_list": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_statement"
+      }
+    },
+    "expression_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "declaration_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "storage_classes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_declaration"
+        }
+      ]
+    },
+    "if_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_if_condition"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "then_statement"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "else"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "else_statement"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_maybe_if_condition": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "if_condition"
+        }
+      ]
+    },
+    "if_condition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "auto"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_ctors"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_ctors"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_basic_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_declarator"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        }
+      ]
+    },
+    "then_statement": {
+      "type": "SYMBOL",
+      "name": "_scope_statement"
+    },
+    "else_statement": {
+      "type": "SYMBOL",
+      "name": "_scope_statement"
+    },
+    "while_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "while"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_if_condition"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "do_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "do"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        },
+        {
+          "type": "STRING",
+          "value": "while"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "for_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "for"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_initialize"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "test"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "increment"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "_maybe_initialize": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_no_scope_non_empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "initialize"
+        }
+      ]
+    },
+    "initialize": {
+      "type": "STRING",
+      "value": ";"
+    },
+    "test": {
+      "type": "SYMBOL",
+      "name": "expression"
+    },
+    "increment": {
+      "type": "SYMBOL",
+      "name": "expression"
+    },
+    "aggregate_foreach": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "foreach"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_type_list"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_aggregate"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "foreach_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "aggregate_foreach"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_no_scope_non_empty_statement"
+        }
+      ]
+    },
+    "foreach": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "foreach"
+        },
+        {
+          "type": "STRING",
+          "value": "foreach_reverse"
+        }
+      ]
+    },
+    "foreach_type_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "foreach_type"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_type"
+        }
+      ]
+    },
+    "foreach_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "foreach_type_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_basic_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_declarator"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "alias"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "foreach_type_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_maybe_foreach_type_attribute"
+      }
+    },
+    "_maybe_foreach_type_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type_ctor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_type_attribute"
+        }
+      ]
+    },
+    "foreach_type_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "ref"
+        },
+        {
+          "type": "STRING",
+          "value": "enum"
+        }
+      ]
+    },
+    "foreach_aggregate": {
+      "type": "SYMBOL",
+      "name": "expression"
+    },
+    "range_foreach": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "foreach"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "foreach_type"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lwr_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ".."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "upr_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "lwr_expression": {
+      "type": "SYMBOL",
+      "name": "expression"
+    },
+    "upr_expression": {
+      "type": "SYMBOL",
+      "name": "expression"
+    },
+    "foreach_range_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "range_foreach"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "switch_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "switch"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "case_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "case"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "scope_statement_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "case_range_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "case"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "first_exp"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "STRING",
+          "value": ".."
+        },
+        {
+          "type": "STRING",
+          "value": "case"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "last_exp"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "scope_statement_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "first_exp": {
+      "type": "SYMBOL",
+      "name": "_maybe_assign_expression"
+    },
+    "last_exp": {
+      "type": "SYMBOL",
+      "name": "_maybe_assign_expression"
+    },
+    "default_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "default"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "scope_statement_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "scope_statement_list": {
+      "type": "SYMBOL",
+      "name": "statement_list_no_case_no_default"
+    },
+    "statement_list_no_case_no_default": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_statement_no_case_no_default"
+      }
+    },
+    "_statement_no_case_no_default": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "empty_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_statement_no_case_no_default"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "scope_block_statement"
+        }
+      ]
+    },
+    "final_switch_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "switch"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "continue_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "continue"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "break_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "break"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "return_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "goto_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "goto"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "STRING",
+              "value": "default"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "case"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "with_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "with"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "symbol"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "template_instance"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "synchronized_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "synchronized"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        }
+      ]
+    },
+    "try_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "try"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_scope_statement"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "catches"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "finally_statement"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "finally_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "catches": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "catch"
+      }
+    },
+    "catch": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "catch"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "catch_parameter"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_no_scope_non_empty_statement"
+        }
+      ]
+    },
+    "catch_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_basic_type"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "finally_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "finally"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_no_scope_non_empty_statement"
+        }
+      ]
+    },
+    "throw_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "throw"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "scope_guard_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "scope"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "exit"
+            },
+            {
+              "type": "STRING",
+              "value": "success"
+            },
+            {
+              "type": "STRING",
+              "value": "failure"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_non_empty_or_scope_block_statement"
+        }
+      ]
+    },
+    "_maybe_asm_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "gcc_asm_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_statement"
+        }
+      ]
+    },
+    "asm_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "asm"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "asm_instruction_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "asm_instruction_list": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "asm_instruction"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ";"
+          }
+        ]
+      }
+    },
+    "mixin_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "_aggregate_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_class_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_interface_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_struct_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_union_declaration"
+        }
+      ]
+    },
+    "_maybe_struct_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "struct_template_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "anon_struct_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "struct_declaration"
+        }
+      ]
+    },
+    "struct_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "struct"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "aggregate_body"
+            }
+          ]
+        }
+      ]
+    },
+    "anon_struct_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "struct"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "aggregate_body"
+        }
+      ]
+    },
+    "_maybe_union_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "union_template_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "anon_union_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "union_declaration"
+        }
+      ]
+    },
+    "union_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "union"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "aggregate_body"
+            }
+          ]
+        }
+      ]
+    },
+    "anon_union_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "union"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "aggregate_body"
+        }
+      ]
+    },
+    "aggregate_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "decl_defs"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "postblit": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_function_body"
+            }
+          ]
+        }
+      ]
+    },
+    "invariant": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "invariant"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "block_statement"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "assert_arguments"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ";"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "block_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "_maybe_class_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "class_template_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_declaration"
+        }
+      ]
+    },
+    "class_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "base_class_list"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "aggregate_body"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "base_class_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "super_class_or_interface"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "interfaces"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "super_class_or_interface": {
+      "type": "SYMBOL",
+      "name": "_maybe_basic_type"
+    },
+    "interfaces": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interface"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interface"
+        }
+      ]
+    },
+    "interface": {
+      "type": "SYMBOL",
+      "name": "_maybe_basic_type"
+    },
+    "_maybe_constructor": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "constructor_template"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constructor"
+        }
+      ]
+    },
+    "constructor": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_body"
+        }
+      ]
+    },
+    "destructor": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_body"
+        }
+      ]
+    },
+    "static_constructor": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_function_body"
+            }
+          ]
+        }
+      ]
+    },
+    "static_destructor": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_function_body"
+            }
+          ]
+        }
+      ]
+    },
+    "shared_static_constructor": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "shared"
+        },
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_function_body"
+            }
+          ]
+        }
+      ]
+    },
+    "shared_static_destructor": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "shared"
+        },
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_function_body"
+            }
+          ]
+        }
+      ]
+    },
+    "allocator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_body"
+        }
+      ]
+    },
+    "deallocator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "delete"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_body"
+        }
+      ]
+    },
+    "alias_this": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "new_anon_class_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "allocator_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "constructor_args"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "super_class_or_interface"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "interfaces"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "aggregate_body"
+        }
+      ]
+    },
+    "constructor_args": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_maybe_interface_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "interface_template_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interface_declaration"
+        }
+      ]
+    },
+    "interface_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "interface"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "base_interface_list"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "aggregate_body"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "base_interface_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interfaces"
+        }
+      ]
+    },
+    "_maybe_enum_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "anonymous_enum_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_declaration"
+        }
+      ]
+    },
+    "enum_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "enum"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "enum_base_type"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_body"
+        }
+      ]
+    },
+    "enum_base_type": {
+      "type": "SYMBOL",
+      "name": "type"
+    },
+    "enum_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "enum_members"
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "enum_members": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "enum_member"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_member"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "enum_member_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_maybe_enum_member_attribute"
+      }
+    },
+    "_maybe_enum_member_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "deprecated_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "user_defined_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_member_attribute"
+        }
+      ]
+    },
+    "enum_member_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "STRING",
+          "value": "disable"
+        }
+      ]
+    },
+    "enum_member": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "enum_member_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "anonymous_enum_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "enum"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ":"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "enum_base_type"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "enum_members"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "anonymous_enum_members"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "anonymous_enum_members": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_maybe_anonymous_enum_member"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_anonymous_enum_member"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_maybe_anonymous_enum_member": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "enum_member"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "anonymous_enum_member"
+        }
+      ]
+    },
+    "anonymous_enum_member": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        }
+      ]
+    },
+    "_maybe_func_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "auto_func_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "func_declaration"
+        }
+      ]
+    },
+    "func_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "storage_classes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_basic_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "func_declarator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_body"
+        }
+      ]
+    },
+    "auto_func_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "storage_classes"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "func_declarator_suffix"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_body"
+        }
+      ]
+    },
+    "func_declarator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_suffixes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "func_declarator_suffix"
+        }
+      ]
+    },
+    "func_declarator_suffix": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "parameters"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "member_function_attributes"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_parameters"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parameters"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "member_function_attributes"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "constraint"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "parameters": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "parameter_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "parameter_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parameter"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "parameter"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "variadic_arguments_attributes"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "parameter_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_basic_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_declarator"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_assign_expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "parameter_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_maybe_in_out"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "user_defined_attribute"
+          }
+        ]
+      }
+    },
+    "_maybe_in_out": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type_ctor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "in_out"
+        }
+      ]
+    },
+    "in_out": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "auto"
+        },
+        {
+          "type": "STRING",
+          "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "STRING",
+          "value": "lazy"
+        },
+        {
+          "type": "STRING",
+          "value": "out"
+        },
+        {
+          "type": "STRING",
+          "value": "ref"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "STRING",
+          "value": "scope"
+        }
+      ]
+    },
+    "variadic_arguments_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "variadic_arguments_attribute"
+      }
+    },
+    "variadic_arguments_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "STRING",
+          "value": "scope"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        }
+      ]
+    },
+    "function_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_function_attribute"
+      }
+    },
+    "_function_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "function_attribute_kwd"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "property"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_at_attribute"
+        }
+      ]
+    },
+    "member_function_attributes": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_maybe_member_function_attribute"
+      }
+    },
+    "_maybe_member_function_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_function_attribute"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "member_function_attribute"
+        }
+      ]
+    },
+    "member_function_attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "const"
+        },
+        {
+          "type": "STRING",
+          "value": "immutable"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "STRING",
+          "value": "scope"
+        },
+        {
+          "type": "STRING",
+          "value": "shared"
+        }
+      ]
+    },
+    "_function_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "specified_function_body"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "missing_function_body"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "shortened_function_body"
+        }
+      ]
+    },
+    "function_literal_body": {
+      "type": "SYMBOL",
+      "name": "specified_function_body"
+    },
+    "specified_function_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "function_contracts"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_in_out_contract_expression"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "do"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "function_contracts"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_in_out_statement"
+                },
+                {
+                  "type": "STRING",
+                  "value": "do"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "missing_function_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "function_contracts"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_in_out_contract_expression"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ";"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_in_out_statement"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "shortened_function_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "function_contracts"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_in_out_contract_expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "function_contracts": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_function_contract"
+      }
+    },
+    "_function_contract": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_in_out_contract_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_in_out_statement"
+        }
+      ]
+    },
+    "_in_out_contract_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "in_contract_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "out_contract_expression"
+        }
+      ]
+    },
+    "_in_out_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "in_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "out_statement"
+        }
+      ]
+    },
+    "in_contract_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assert_arguments"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "out_contract_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "out"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assert_arguments"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "in_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "out_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "out"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "template_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "constraint"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "decl_defs"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "template_parameters": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_parameter_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "template_parameter_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_template_parameter"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_template_parameter"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_template_parameter": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "template_type_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_value_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_alias_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_sequence_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_this_parameter"
+        }
+      ]
+    },
+    "template_instance": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_arguments"
+        }
+      ]
+    },
+    "template_arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "template_argument_list"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "template_single_argument"
+            }
+          ]
+        }
+      ]
+    },
+    "template_argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_template_argument"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_template_argument"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_template_argument": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol"
+        }
+      ]
+    },
+    "symbol": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol_tail"
+        }
+      ]
+    },
+    "symbol_tail": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "template_instance"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "."
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "symbol_tail"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "template_single_argument": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fundamental_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "character_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        },
+        {
+          "type": "STRING",
+          "value": "true"
+        },
+        {
+          "type": "STRING",
+          "value": "false"
+        },
+        {
+          "type": "STRING",
+          "value": "null"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "special_keyword"
+        }
+      ]
+    },
+    "template_type_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_type_parameter_specialization"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_type_parameter_default"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "template_type_parameter_specialization": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "template_type_parameter_default": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "template_this_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_type_parameter"
+        }
+      ]
+    },
+    "template_value_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_basic_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_declarator"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_value_parameter_specialization"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_value_parameter_default"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "template_value_parameter_specialization": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_conditional_expression"
+        }
+      ]
+    },
+    "template_value_parameter_default": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_assign_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "special_keyword"
+            }
+          ]
+        }
+      ]
+    },
+    "template_alias_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_basic_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_declarator"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_alias_parameter_specialization"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_alias_parameter_default"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "template_alias_parameter_specialization": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_conditional_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "template_alias_parameter_default": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_conditional_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "template_sequence_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "..."
+        }
+      ]
+    },
+    "constructor_template": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "member_function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "constraint"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_function_body"
+            }
+          ]
+        }
+      ]
+    },
+    "class_template_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "constraint"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "base_class_list"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "base_class_list"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "constraint"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "aggregate_body"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "interface_template_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "interface"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "base_interface_list"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "constraint"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "constraint"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "base_interface_list"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "aggregate_body"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "struct_template_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "struct"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "constraint"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "aggregate_body"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "union_template_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "union"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "constraint"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "aggregate_body"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "constraint": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "template_mixin_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "constraint"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "decl_defs"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "template_mixin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "mixin"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_mixin_template_name"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "_maybe_mixin_template_name": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "mixin_qualified_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mixin_template_name"
+        }
+      ]
+    },
+    "mixin_template_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "typeof"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mixin_qualified_identifier"
+        }
+      ]
+    },
+    "mixin_qualified_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "template_instance"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "mixin_qualified_identifier"
+            }
+          ]
+        }
+      ]
+    },
+    "conditional_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_condition"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_maybe_declaration_block"
+                },
+                {
+                  "type": "STRING",
+                  "value": "else"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_declaration_block"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "decl_defs"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "conditional_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_condition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_no_scope_non_empty_statement"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "else"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_no_scope_non_empty_statement"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_condition": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "version_condition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "debug_condition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "static_if_condition"
+        }
+      ]
+    },
+    "version_condition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "version"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "integer_literal"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "STRING",
+              "value": "unittest"
+            },
+            {
+              "type": "STRING",
+              "value": "assert"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "version_specification": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "version"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "integer_literal"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "debug_condition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "debug"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "integer_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "debug_specification": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "debug"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "integer_literal"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "static_if_condition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "static_foreach": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "aggregate_foreach"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "range_foreach"
+            }
+          ]
+        }
+      ]
+    },
+    "static_foreach_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "static_foreach"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_declaration_block"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "decl_defs"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "static_foreach_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "static_foreach"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_no_scope_non_empty_statement"
+        }
+      ]
+    },
+    "static_assert": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "assert"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assert_arguments"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
+    "traits_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "__traits"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "traits_keyword"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "traits_arguments"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "traits_keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "isAbstractClass"
+        },
+        {
+          "type": "STRING",
+          "value": "isArithmetic"
+        },
+        {
+          "type": "STRING",
+          "value": "isAssociativeArray"
+        },
+        {
+          "type": "STRING",
+          "value": "isFinalClass"
+        },
+        {
+          "type": "STRING",
+          "value": "isPOD"
+        },
+        {
+          "type": "STRING",
+          "value": "isNested"
+        },
+        {
+          "type": "STRING",
+          "value": "isFuture"
+        },
+        {
+          "type": "STRING",
+          "value": "isDeprecated"
+        },
+        {
+          "type": "STRING",
+          "value": "isFloating"
+        },
+        {
+          "type": "STRING",
+          "value": "isIntegral"
+        },
+        {
+          "type": "STRING",
+          "value": "isScalar"
+        },
+        {
+          "type": "STRING",
+          "value": "isStaticArray"
+        },
+        {
+          "type": "STRING",
+          "value": "isUnsigned"
+        },
+        {
+          "type": "STRING",
+          "value": "isDisabled"
+        },
+        {
+          "type": "STRING",
+          "value": "isVirtualFunction"
+        },
+        {
+          "type": "STRING",
+          "value": "isVirtualMethod"
+        },
+        {
+          "type": "STRING",
+          "value": "isAbstractFunction"
+        },
+        {
+          "type": "STRING",
+          "value": "isFinalFunction"
+        },
+        {
+          "type": "STRING",
+          "value": "isStaticFunction"
+        },
+        {
+          "type": "STRING",
+          "value": "isOverrideFunction"
+        },
+        {
+          "type": "STRING",
+          "value": "isTemplate"
+        },
+        {
+          "type": "STRING",
+          "value": "isRef"
+        },
+        {
+          "type": "STRING",
+          "value": "isOut"
+        },
+        {
+          "type": "STRING",
+          "value": "isLazy"
+        },
+        {
+          "type": "STRING",
+          "value": "isReturnOnStack"
+        },
+        {
+          "type": "STRING",
+          "value": "isCopyable"
+        },
+        {
+          "type": "STRING",
+          "value": "isZeroInit"
+        },
+        {
+          "type": "STRING",
+          "value": "isModule"
+        },
+        {
+          "type": "STRING",
+          "value": "isPackage"
+        },
+        {
+          "type": "STRING",
+          "value": "hasMember"
+        },
+        {
+          "type": "STRING",
+          "value": "hasCopyConstructor"
+        },
+        {
+          "type": "STRING",
+          "value": "hasPostblit"
+        },
+        {
+          "type": "STRING",
+          "value": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "getAliasThis"
+        },
+        {
+          "type": "STRING",
+          "value": "getAttributes"
+        },
+        {
+          "type": "STRING",
+          "value": "getFunctionAttributes"
+        },
+        {
+          "type": "STRING",
+          "value": "getFunctionVariadicStyle"
+        },
+        {
+          "type": "STRING",
+          "value": "getLinkage"
+        },
+        {
+          "type": "STRING",
+          "value": "getLocation"
+        },
+        {
+          "type": "STRING",
+          "value": "getMember"
+        },
+        {
+          "type": "STRING",
+          "value": "getOverloads"
+        },
+        {
+          "type": "STRING",
+          "value": "getParameterStorageClasses"
+        },
+        {
+          "type": "STRING",
+          "value": "getPointerBitmap"
+        },
+        {
+          "type": "STRING",
+          "value": "getCppNamespaces"
+        },
+        {
+          "type": "STRING",
+          "value": "getVisibility"
+        },
+        {
+          "type": "STRING",
+          "value": "getProtection"
+        },
+        {
+          "type": "STRING",
+          "value": "getTargetInfo"
+        },
+        {
+          "type": "STRING",
+          "value": "getVirtualFunctions"
+        },
+        {
+          "type": "STRING",
+          "value": "getVirtualMethods"
+        },
+        {
+          "type": "STRING",
+          "value": "getUnitTests"
+        },
+        {
+          "type": "STRING",
+          "value": "parent"
+        },
+        {
+          "type": "STRING",
+          "value": "child"
+        },
+        {
+          "type": "STRING",
+          "value": "classInstanceSize"
+        },
+        {
+          "type": "STRING",
+          "value": "getVirtualIndex"
+        },
+        {
+          "type": "STRING",
+          "value": "allMembers"
+        },
+        {
+          "type": "STRING",
+          "value": "derivedMembers"
+        },
+        {
+          "type": "STRING",
+          "value": "isSame"
+        },
+        {
+          "type": "STRING",
+          "value": "compiles"
+        },
+        {
+          "type": "STRING",
+          "value": "toType"
+        }
+      ]
+    },
+    "traits_arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_traits_argument"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_traits_argument"
+        }
+      ]
+    },
+    "_traits_argument": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "unit_test": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "unittest"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_statement"
+        }
+      ]
+    },
+    "asm_instruction": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "STRING",
+                "value": ":"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": ":"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "align"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_integer_expression"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "even"
+            },
+            {
+              "type": "STRING",
+              "value": "naked"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "db"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "ds"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "di"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dl"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "df"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dw"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dd"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dq"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "de"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "opcode"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "operands"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "db"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "ds"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "di"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dl"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dw"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "dq"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_string_literal"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "opcode"
+            }
+          ]
+        }
+      ]
+    },
+    "opcode": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "int"
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "STRING",
+          "value": "out"
+        }
+      ]
+    },
+    "operands": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "operand"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operand"
+        }
+      ]
+    },
+    "_integer_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "register": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "AL"
+        },
+        {
+          "type": "STRING",
+          "value": "AH"
+        },
+        {
+          "type": "STRING",
+          "value": "AX"
+        },
+        {
+          "type": "STRING",
+          "value": "EAX"
+        },
+        {
+          "type": "STRING",
+          "value": "BL"
+        },
+        {
+          "type": "STRING",
+          "value": "BH"
+        },
+        {
+          "type": "STRING",
+          "value": "BX"
+        },
+        {
+          "type": "STRING",
+          "value": "EBX"
+        },
+        {
+          "type": "STRING",
+          "value": "CL"
+        },
+        {
+          "type": "STRING",
+          "value": "CH"
+        },
+        {
+          "type": "STRING",
+          "value": "CX"
+        },
+        {
+          "type": "STRING",
+          "value": "ECX"
+        },
+        {
+          "type": "STRING",
+          "value": "DL"
+        },
+        {
+          "type": "STRING",
+          "value": "DH"
+        },
+        {
+          "type": "STRING",
+          "value": "DX"
+        },
+        {
+          "type": "STRING",
+          "value": "EDX"
+        },
+        {
+          "type": "STRING",
+          "value": "BP"
+        },
+        {
+          "type": "STRING",
+          "value": "EBP"
+        },
+        {
+          "type": "STRING",
+          "value": "SP"
+        },
+        {
+          "type": "STRING",
+          "value": "ESP"
+        },
+        {
+          "type": "STRING",
+          "value": "DI"
+        },
+        {
+          "type": "STRING",
+          "value": "EDI"
+        },
+        {
+          "type": "STRING",
+          "value": "SI"
+        },
+        {
+          "type": "STRING",
+          "value": "ESI"
+        },
+        {
+          "type": "STRING",
+          "value": "ES"
+        },
+        {
+          "type": "STRING",
+          "value": "CS"
+        },
+        {
+          "type": "STRING",
+          "value": "SS"
+        },
+        {
+          "type": "STRING",
+          "value": "DS"
+        },
+        {
+          "type": "STRING",
+          "value": "GS"
+        },
+        {
+          "type": "STRING",
+          "value": "FS"
+        },
+        {
+          "type": "STRING",
+          "value": "CR0"
+        },
+        {
+          "type": "STRING",
+          "value": "CR2"
+        },
+        {
+          "type": "STRING",
+          "value": "CR3"
+        },
+        {
+          "type": "STRING",
+          "value": "CR4"
+        },
+        {
+          "type": "STRING",
+          "value": "DR0"
+        },
+        {
+          "type": "STRING",
+          "value": "DR1"
+        },
+        {
+          "type": "STRING",
+          "value": "DR2"
+        },
+        {
+          "type": "STRING",
+          "value": "DR3"
+        },
+        {
+          "type": "STRING",
+          "value": "DR6"
+        },
+        {
+          "type": "STRING",
+          "value": "DR7"
+        },
+        {
+          "type": "STRING",
+          "value": "TR3"
+        },
+        {
+          "type": "STRING",
+          "value": "TR4"
+        },
+        {
+          "type": "STRING",
+          "value": "TR5"
+        },
+        {
+          "type": "STRING",
+          "value": "TR6"
+        },
+        {
+          "type": "STRING",
+          "value": "TR7"
+        },
+        {
+          "type": "STRING",
+          "value": "ST"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(0)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(1)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(2)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(3)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(4)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(5)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(6)"
+        },
+        {
+          "type": "STRING",
+          "value": "ST(7)"
+        },
+        {
+          "type": "STRING",
+          "value": "MM0"
+        },
+        {
+          "type": "STRING",
+          "value": "MM1"
+        },
+        {
+          "type": "STRING",
+          "value": "MM2"
+        },
+        {
+          "type": "STRING",
+          "value": "MM3"
+        },
+        {
+          "type": "STRING",
+          "value": "MM4"
+        },
+        {
+          "type": "STRING",
+          "value": "MM5"
+        },
+        {
+          "type": "STRING",
+          "value": "MM6"
+        },
+        {
+          "type": "STRING",
+          "value": "MM7"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM0"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM1"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM2"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM3"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM4"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM5"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM6"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM7"
+        }
+      ]
+    },
+    "register64": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "RAX"
+        },
+        {
+          "type": "STRING",
+          "value": "RBX"
+        },
+        {
+          "type": "STRING",
+          "value": "RCX"
+        },
+        {
+          "type": "STRING",
+          "value": "RDX"
+        },
+        {
+          "type": "STRING",
+          "value": "BPL"
+        },
+        {
+          "type": "STRING",
+          "value": "RBP"
+        },
+        {
+          "type": "STRING",
+          "value": "SPL"
+        },
+        {
+          "type": "STRING",
+          "value": "RSP"
+        },
+        {
+          "type": "STRING",
+          "value": "DIL"
+        },
+        {
+          "type": "STRING",
+          "value": "RDI"
+        },
+        {
+          "type": "STRING",
+          "value": "SIL"
+        },
+        {
+          "type": "STRING",
+          "value": "RSI"
+        },
+        {
+          "type": "STRING",
+          "value": "R8B"
+        },
+        {
+          "type": "STRING",
+          "value": "R8W"
+        },
+        {
+          "type": "STRING",
+          "value": "R8D"
+        },
+        {
+          "type": "STRING",
+          "value": "R8"
+        },
+        {
+          "type": "STRING",
+          "value": "R9B"
+        },
+        {
+          "type": "STRING",
+          "value": "R9W"
+        },
+        {
+          "type": "STRING",
+          "value": "R9D"
+        },
+        {
+          "type": "STRING",
+          "value": "R9"
+        },
+        {
+          "type": "STRING",
+          "value": "R10B"
+        },
+        {
+          "type": "STRING",
+          "value": "R10W"
+        },
+        {
+          "type": "STRING",
+          "value": "R10D"
+        },
+        {
+          "type": "STRING",
+          "value": "R10"
+        },
+        {
+          "type": "STRING",
+          "value": "R11B"
+        },
+        {
+          "type": "STRING",
+          "value": "R11W"
+        },
+        {
+          "type": "STRING",
+          "value": "R11D"
+        },
+        {
+          "type": "STRING",
+          "value": "R11"
+        },
+        {
+          "type": "STRING",
+          "value": "R12B"
+        },
+        {
+          "type": "STRING",
+          "value": "R12W"
+        },
+        {
+          "type": "STRING",
+          "value": "R12D"
+        },
+        {
+          "type": "STRING",
+          "value": "R12"
+        },
+        {
+          "type": "STRING",
+          "value": "R13B"
+        },
+        {
+          "type": "STRING",
+          "value": "R13W"
+        },
+        {
+          "type": "STRING",
+          "value": "R13D"
+        },
+        {
+          "type": "STRING",
+          "value": "R13"
+        },
+        {
+          "type": "STRING",
+          "value": "R14B"
+        },
+        {
+          "type": "STRING",
+          "value": "R14W"
+        },
+        {
+          "type": "STRING",
+          "value": "R14D"
+        },
+        {
+          "type": "STRING",
+          "value": "R14"
+        },
+        {
+          "type": "STRING",
+          "value": "R15B"
+        },
+        {
+          "type": "STRING",
+          "value": "R15W"
+        },
+        {
+          "type": "STRING",
+          "value": "R15D"
+        },
+        {
+          "type": "STRING",
+          "value": "R15"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM8"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM9"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM10"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM11"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM12"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM13"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM14"
+        },
+        {
+          "type": "STRING",
+          "value": "XMM15"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM0"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM1"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM2"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM3"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM4"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM5"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM6"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM7"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM8"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM9"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM10"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM11"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM12"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM13"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM14"
+        },
+        {
+          "type": "STRING",
+          "value": "YMM15"
+        }
+      ]
+    },
+    "operand": {
+      "type": "SYMBOL",
+      "name": "_maybe_asm_exp"
+    },
+    "_maybe_asm_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_log_or_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_exp"
+        }
+      ]
+    },
+    "asm_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_log_or_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "?"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_exp"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_exp"
+        }
+      ]
+    },
+    "_maybe_asm_log_or_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_log_and_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_log_or_exp"
+        }
+      ]
+    },
+    "asm_log_or_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_log_or_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "||"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_log_and_exp"
+        }
+      ]
+    },
+    "_maybe_asm_log_and_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_or_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_log_and_exp"
+        }
+      ]
+    },
+    "asm_log_and_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_log_and_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "&&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_or_exp"
+        }
+      ]
+    },
+    "_maybe_asm_or_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_xor_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_or_exp"
+        }
+      ]
+    },
+    "asm_or_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_or_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_xor_exp"
+        }
+      ]
+    },
+    "_maybe_asm_xor_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_and_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_xor_exp"
+        }
+      ]
+    },
+    "asm_xor_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_xor_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_and_exp"
+        }
+      ]
+    },
+    "_maybe_asm_and_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_equal_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_and_exp"
+        }
+      ]
+    },
+    "asm_and_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_and_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_equal_exp"
+        }
+      ]
+    },
+    "_maybe_asm_equal_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_rel_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_equal_exp"
+        }
+      ]
+    },
+    "asm_equal_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_equal_exp"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=="
+            },
+            {
+              "type": "STRING",
+              "value": "!="
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_rel_exp"
+        }
+      ]
+    },
+    "_maybe_asm_rel_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_shift_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_rel_exp"
+        }
+      ]
+    },
+    "asm_rel_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_rel_exp"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "STRING",
+              "value": "<="
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            },
+            {
+              "type": "STRING",
+              "value": ">="
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_shift_exp"
+        }
+      ]
+    },
+    "_maybe_asm_shift_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_add_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_shift_exp"
+        }
+      ]
+    },
+    "asm_shift_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_shift_exp"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<<"
+            },
+            {
+              "type": "STRING",
+              "value": ">>"
+            },
+            {
+              "type": "STRING",
+              "value": ">>>"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_add_exp"
+        }
+      ]
+    },
+    "_maybe_asm_add_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_mul_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_add_exp"
+        }
+      ]
+    },
+    "asm_add_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_add_exp"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "+"
+            },
+            {
+              "type": "STRING",
+              "value": "-"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_mul_exp"
+        }
+      ]
+    },
+    "_maybe_asm_mul_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_br_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_mul_exp"
+        }
+      ]
+    },
+    "asm_mul_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_mul_exp"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "STRING",
+              "value": "/"
+            },
+            {
+              "type": "STRING",
+              "value": "%"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_br_exp"
+        }
+      ]
+    },
+    "_maybe_asm_br_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_una_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_br_exp"
+        }
+      ]
+    },
+    "asm_br_exp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_br_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_asm_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_maybe_asm_una_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "asm_primary_exp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm_una_exp"
+        }
+      ]
+    },
+    "asm_una_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "asm_type_prefix"
+                },
+                {
+                  "type": "STRING",
+                  "value": "offsetof"
+                },
+                {
+                  "type": "STRING",
+                  "value": "seg"
+                },
+                {
+                  "type": "STRING",
+                  "value": "short"
+                },
+                {
+                  "type": "STRING",
+                  "value": "near"
+                },
+                {
+                  "type": "STRING",
+                  "value": "far"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_asm_exp"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_asm_exp"
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "+"
+                },
+                {
+                  "type": "STRING",
+                  "value": "-"
+                },
+                {
+                  "type": "STRING",
+                  "value": "!"
+                },
+                {
+                  "type": "STRING",
+                  "value": "~"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_asm_una_exp"
+            }
+          ]
+        }
+      ]
+    },
+    "asm_primary_exp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        },
+        {
+          "type": "STRING",
+          "value": "__LOCAL_SIZE"
+        },
+        {
+          "type": "STRING",
+          "value": "$"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "register"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "register64"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ":"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_maybe_asm_exp"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dot_identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "this"
+        }
+      ]
+    },
+    "dot_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "dot_identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "fundamental_type"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        }
+      ]
+    },
+    "asm_type_prefix": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "near"
+            },
+            {
+              "type": "STRING",
+              "value": "far"
+            },
+            {
+              "type": "STRING",
+              "value": "word"
+            },
+            {
+              "type": "STRING",
+              "value": "dword"
+            },
+            {
+              "type": "STRING",
+              "value": "qword"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "fundamental_type"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "ptr"
+        }
+      ]
+    },
+    "gcc_asm_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "asm"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "function_attributes"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gcc_asm_instruction_list"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "gcc_asm_instruction_list": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_gcc_asm_instruction"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ";"
+          }
+        ]
+      }
+    },
+    "_gcc_asm_instruction": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "gcc_basic_asm_instruction"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gcc_ext_asm_instruction"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gcc_goto_asm_instruction"
+        }
+      ]
+    },
+    "gcc_basic_asm_instruction": {
+      "type": "SYMBOL",
+      "name": "_maybe_assign_expression"
+    },
+    "gcc_ext_asm_instruction": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "gcc_asm_operands"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "gcc_asm_operands"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ":"
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_maybe_gcc_asm_clobbers"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "gcc_goto_asm_instruction": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "gcc_asm_operands"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_maybe_gcc_asm_clobbers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "gcc_asm_goto_labels"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "gcc_asm_operands": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "gcc_symbolic_name"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_string_literal"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_assign_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "gcc_asm_operands"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "gcc_symbolic_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_maybe_gcc_asm_clobbers": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gcc_asm_clobbers"
+        }
+      ]
+    },
+    "gcc_asm_clobbers": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_string_literal"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_maybe_gcc_asm_clobbers"
+        }
+      ]
+    },
+    "gcc_asm_goto_labels": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "gcc_asm_goto_labels"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "extras": [
+    {
+      "type": "SYMBOL",
+      "name": "_white_space"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_end_of_line"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "line_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "nesting_block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "special_token_sequence"
+    }
+  ],
+  "conflicts": [
+    [
+      "argument_list",
+      "first_exp"
+    ],
+    [
+      "qualified_identifier"
+    ],
+    [
+      "storage_class",
+      "attribute"
+    ],
+    [
+      "storage_class",
+      "enum_declaration"
+    ],
+    [
+      "storage_class",
+      "function_attribute_kwd"
+    ],
+    [
+      "storage_class",
+      "type_ctor"
+    ],
+    [
+      "storage_class",
+      "type_ctor",
+      "attribute"
+    ],
+    [
+      "storage_class",
+      "attribute",
+      "synchronized_statement"
+    ],
+    [
+      "attribute",
+      "static_destructor"
+    ],
+    [
+      "attribute",
+      "static_constructor"
+    ],
+    [
+      "attribute",
+      "synchronized_statement"
+    ],
+    [
+      "_decl_def",
+      "_declaration"
+    ],
+    [
+      "alias_assignment",
+      "qualified_identifier"
+    ],
+    [
+      "template_instance",
+      "mixin_qualified_identifier"
+    ],
+    [
+      "auto_assignment",
+      "qualified_identifier",
+      "auto_func_declaration"
+    ],
+    [
+      "var_declarator",
+      "func_declarator"
+    ],
+    [
+      "primary_expression",
+      "template_instance"
+    ],
+    [
+      "type_ctor",
+      "variadic_arguments_attribute"
+    ],
+    [
+      "in_out",
+      "variadic_arguments_attribute"
+    ],
+    [
+      "parameter_attributes"
+    ],
+    [
+      "storage_class",
+      "synchronized_statement"
+    ],
+    [
+      "_declaration",
+      "_non_empty_statement_no_case_no_default"
+    ],
+    [
+      "qualified_identifier",
+      "template_sequence_parameter"
+    ],
+    [
+      "qualified_identifier",
+      "template_type_parameter"
+    ],
+    [
+      "qualified_identifier",
+      "template_instance"
+    ],
+    [
+      "unary_expression",
+      "parameter"
+    ],
+    [
+      "new_expression"
+    ],
+    [
+      "type"
+    ],
+    [
+      "attribute",
+      "return_statement"
+    ],
+    [
+      "primary_expression",
+      "postblit",
+      "constructor",
+      "constructor_template"
+    ],
+    [
+      "_decl_def",
+      "declaration_statement"
+    ],
+    [
+      "_decl_def",
+      "_non_empty_statement_no_case_no_default"
+    ],
+    [
+      "foreach_type_list",
+      "range_foreach"
+    ],
+    [
+      "foreach_type_attributes"
+    ],
+    [
+      "parameter",
+      "template_value_parameter"
+    ],
+    [
+      "conditional_declaration"
+    ],
+    [
+      "or_or_expression",
+      "and_and_expression"
+    ],
+    [
+      "and_and_expression",
+      "or_expression"
+    ],
+    [
+      "or_expression",
+      "xor_expression"
+    ],
+    [
+      "xor_expression",
+      "and_expression"
+    ],
+    [
+      "_cmp_expression",
+      "rel_expression",
+      "shift_expression"
+    ],
+    [
+      "_cmp_expression",
+      "rel_expression"
+    ],
+    [
+      "_cmp_expression",
+      "identity_expression",
+      "in_expression"
+    ],
+    [
+      "_cmp_expression",
+      "equal_expression"
+    ],
+    [
+      "_cmp_expression",
+      "in_expression"
+    ],
+    [
+      "_cmp_expression",
+      "identity_expression"
+    ],
+    [
+      "shift_expression",
+      "add_expression"
+    ],
+    [
+      "shift_expression",
+      "cat_expression"
+    ],
+    [
+      "add_expression",
+      "mul_expression"
+    ],
+    [
+      "_maybe_pow_expression",
+      "postfix_expression"
+    ],
+    [
+      "_maybe_pow_expression",
+      "index_expression",
+      "slice_expression"
+    ],
+    [
+      "_maybe_pow_expression",
+      "pow_expression"
+    ],
+    [
+      "super_class_or_interface",
+      "interface"
+    ],
+    [
+      "postfix_expression",
+      "template_instance"
+    ],
+    [
+      "argument_list",
+      "slice"
+    ],
+    [
+      "primary_expression",
+      "symbol_tail"
+    ],
+    [
+      "type_suffix",
+      "unary_expression"
+    ],
+    [
+      "specified_function_body",
+      "missing_function_body"
+    ],
+    [
+      "primary_expression",
+      "destructor"
+    ],
+    [
+      "declaration_block",
+      "block_statement"
+    ],
+    [
+      "parameter_with_member_attributes",
+      "deallocator"
+    ],
+    [
+      "conditional_statement"
+    ],
+    [
+      "static_constructor",
+      "missing_function_body"
+    ],
+    [
+      "postblit",
+      "missing_function_body"
+    ],
+    [
+      "array_initializer",
+      "array_literal"
+    ],
+    [
+      "exp_initializer",
+      "argument_list"
+    ],
+    [
+      "array_member_initialization",
+      "key_expression"
+    ],
+    [
+      "struct_initializer",
+      "block_statement"
+    ],
+    [
+      "mixin_type",
+      "mixin_expression"
+    ],
+    [
+      "qualified_identifier",
+      "symbol_tail"
+    ],
+    [
+      "asm_rel_exp",
+      "asm_shift_exp"
+    ],
+    [
+      "mixin_expression",
+      "mixin_statement"
+    ],
+    [
+      "primary_expression",
+      "synchronized_statement"
+    ],
+    [
+      "try_statement"
+    ],
+    [
+      "type_suffix",
+      "array_literal"
+    ],
+    [
+      "type_suffix",
+      "argument_list"
+    ],
+    [
+      "shared_static_constructor",
+      "missing_function_body"
+    ],
+    [
+      "static_destructor",
+      "missing_function_body"
+    ],
+    [
+      "parameter",
+      "template_value_parameter_default"
+    ],
+    [
+      "unary_expression",
+      "template_instance"
+    ],
+    [
+      "rel_expression",
+      "shift_expression"
+    ],
+    [
+      "equal_expression",
+      "shift_expression"
+    ],
+    [
+      "in_expression",
+      "shift_expression"
+    ],
+    [
+      "identity_expression",
+      "shift_expression"
+    ],
+    [
+      "cat_expression",
+      "mul_expression"
+    ],
+    [
+      "slice"
+    ],
+    [
+      "asm_log_or_exp",
+      "asm_log_and_exp"
+    ],
+    [
+      "asm_log_and_exp",
+      "asm_or_exp"
+    ],
+    [
+      "asm_or_exp",
+      "asm_xor_exp"
+    ],
+    [
+      "asm_xor_exp",
+      "asm_and_exp"
+    ],
+    [
+      "asm_and_exp",
+      "asm_equal_exp"
+    ],
+    [
+      "asm_equal_exp",
+      "asm_rel_exp"
+    ],
+    [
+      "asm_shift_exp",
+      "asm_add_exp"
+    ],
+    [
+      "asm_add_exp",
+      "asm_mul_exp"
+    ],
+    [
+      "asm_mul_exp",
+      "asm_br_exp"
+    ],
+    [
+      "mixin_declaration",
+      "mixin_expression",
+      "mixin_statement"
+    ],
+    [
+      "shared_static_destructor",
+      "missing_function_body"
+    ],
+    [
+      "if_statement"
+    ],
+    [
+      "mixin_declaration",
+      "mixin_statement"
+    ],
+    [
+      "alt_declarator_suffix",
+      "qualified_identifier"
+    ],
+    [
+      "storage_classes"
+    ],
+    [
+      "type_ctors"
+    ],
+    [
+      "function_contracts"
+    ],
+    [
+      "decl_defs"
+    ],
+    [
+      "type_suffixes"
+    ],
+    [
+      "statement_list_no_case_no_default"
+    ],
+    [
+      "catches"
+    ],
+    [
+      "pragma_statement",
+      "empty_statement"
+    ],
+    [
+      "empty_declaration",
+      "empty_statement"
+    ],
+    [
+      "static_foreach_declaration"
+    ],
+    [
+      "debug_condition"
+    ],
+    [
+      "scope_block_statement",
+      "function_literal_body"
+    ],
+    [
+      "labeled_statement"
+    ],
+    [
+      "_scope_statement",
+      "function_literal_body"
+    ],
+    [
+      "_no_scope_statement",
+      "function_literal_body"
+    ],
+    [
+      "_no_scope_non_empty_statement",
+      "function_literal_body"
+    ],
+    [
+      "struct_member_initializer",
+      "labeled_statement"
+    ],
+    [
+      "packages"
+    ],
+    [
+      "qualified_identifier",
+      "primary_expression"
+    ],
+    [
+      "basic_type",
+      "primary_expression"
+    ],
+    [
+      "qualified_identifier",
+      "primary_expression",
+      "symbol_tail"
+    ],
+    [
+      "_maybe_assign_expression",
+      "assign_expression"
+    ],
+    [
+      "_maybe_conditional_expression",
+      "or_or_expression"
+    ],
+    [
+      "_maybe_conditional_expression",
+      "conditional_expression"
+    ],
+    [
+      "_maybe_or_or_expression",
+      "and_and_expression"
+    ],
+    [
+      "_maybe_and_and_expression",
+      "or_expression"
+    ],
+    [
+      "_maybe_or_expression",
+      "xor_expression"
+    ],
+    [
+      "_maybe_xor_expression",
+      "and_expression"
+    ],
+    [
+      "_maybe_shift_expression",
+      "add_expression"
+    ],
+    [
+      "_maybe_shift_expression",
+      "cat_expression"
+    ],
+    [
+      "exp_initializer",
+      "_maybe_comma_expression"
+    ],
+    [
+      "_maybe_asm_rel_exp",
+      "asm_shift_exp"
+    ],
+    [
+      "_maybe_asm_exp",
+      "asm_log_or_exp"
+    ],
+    [
+      "_maybe_asm_exp",
+      "asm_exp"
+    ],
+    [
+      "_maybe_asm_log_or_exp",
+      "asm_log_and_exp"
+    ],
+    [
+      "_maybe_asm_log_and_exp",
+      "asm_or_exp"
+    ],
+    [
+      "_maybe_asm_or_exp",
+      "asm_xor_exp"
+    ],
+    [
+      "_maybe_asm_xor_exp",
+      "asm_and_exp"
+    ],
+    [
+      "_maybe_asm_and_exp",
+      "asm_equal_exp"
+    ],
+    [
+      "_maybe_asm_equal_exp",
+      "asm_rel_exp"
+    ],
+    [
+      "_maybe_asm_shift_exp",
+      "asm_add_exp"
+    ],
+    [
+      "_maybe_asm_add_exp",
+      "asm_mul_exp"
+    ],
+    [
+      "_maybe_asm_mul_exp",
+      "asm_br_exp"
+    ],
+    [
+      "storage_class",
+      "attribute",
+      "shared_static_constructor",
+      "shared_static_destructor"
+    ],
+    [
+      "import_declaration",
+      "attribute"
+    ],
+    [
+      "_maybe_storage_class",
+      "_maybe_at_attribute"
+    ],
+    [
+      "_maybe_storage_class",
+      "_maybe_attribute"
+    ],
+    [
+      "_module_attribute",
+      "_maybe_attribute"
+    ],
+    [
+      "_module_attribute",
+      "_maybe_at_attribute"
+    ],
+    [
+      "_maybe_basic_type",
+      "primary_expression"
+    ],
+    [
+      "type_ctors",
+      "_maybe_in_out"
+    ],
+    [
+      "enum_members",
+      "_maybe_anonymous_enum_member"
+    ],
+    [
+      "_maybe_basic_type",
+      "basic_type"
+    ],
+    [
+      "_maybe_attribute",
+      "pragma_statement"
+    ],
+    [
+      "_decl_def",
+      "_declaration",
+      "_non_empty_statement_no_case_no_default"
+    ],
+    [
+      "var_declarator_identifier",
+      "alt_declarator_identifier"
+    ],
+    [
+      "_maybe_add_expression",
+      "mul_expression"
+    ],
+    [
+      "primary_expression",
+      "with_statement",
+      "symbol_tail"
+    ],
+    [
+      "alt_declarator_inner",
+      "qualified_identifier",
+      "primary_expression"
+    ],
+    [
+      "alt_declarator_inner",
+      "primary_expression"
+    ],
+    [
+      "alt_declarator",
+      "qualified_identifier",
+      "primary_expression"
+    ],
+    [
+      "primary_expression",
+      "template_value_parameter_default"
+    ],
+    [
+      "asm_primary_exp"
+    ],
+    [
+      "_maybe_at_attribute",
+      "_function_attribute"
+    ],
+    [
+      "user_defined_attribute"
+    ],
+    [
+      "user_defined_attribute",
+      "template_instance"
+    ],
+    [
+      "import_declaration",
+      "storage_class"
+    ],
+    [
+      "import_declaration",
+      "storage_class",
+      "attribute"
+    ],
+    [
+      "var_declarations"
+    ],
+    [
+      "func_declaration"
+    ],
+    [
+      "float_literal",
+      "primary_expression"
+    ],
+    [
+      "float_literal",
+      "template_single_argument"
+    ],
+    [
+      "token_no_braces",
+      "float_literal"
+    ],
+    [
+      "default_statement"
+    ],
+    [
+      "case_statement"
+    ],
+    [
+      "case_range_statement"
+    ],
+    [
+      "storage_class",
+      "deprecated_attribute"
+    ],
+    [
+      "_cmp_expression",
+      "shift_expression"
+    ],
+    [
+      "scope_block_statement",
+      "specified_function_body"
+    ],
+    [
+      "specified_function_body"
+    ],
+    [
+      "_scope_statement",
+      "specified_function_body"
+    ],
+    [
+      "_no_scope_statement",
+      "specified_function_body"
+    ],
+    [
+      "_no_scope_non_empty_statement",
+      "specified_function_body"
+    ],
+    [
+      "missing_function_body",
+      "_function_contract"
+    ],
+    [
+      "primary_expression",
+      "parameter"
+    ],
+    [
+      "alias_assign",
+      "primary_expression"
+    ],
+    [
+      "type_suffix"
+    ],
+    [
+      "member_function_attributes"
+    ],
+    [
+      "function_attributes"
+    ],
+    [
+      "qualified_identifier",
+      "primary_expression",
+      "template_instance"
+    ],
+    [
+      "void_initializer",
+      "fundamental_type"
+    ],
+    [
+      "type",
+      "postfix_expression"
+    ],
+    [
+      "_maybe_basic_type",
+      "basic_type",
+      "primary_expression"
+    ],
+    [
+      "primary_expression",
+      "opcode"
+    ],
+    [
+      "primary_expression",
+      "template_instance",
+      "opcode"
+    ],
+    [
+      "primary_expression",
+      "asm_instruction"
+    ],
+    [
+      "asm_instruction_list",
+      "gcc_asm_instruction_list"
+    ],
+    [
+      "qualified_identifier",
+      "primary_expression",
+      "opcode"
+    ]
+  ],
+  "precedences": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "nesting_block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "delimited_string"
+    }
+  ],
+  "inline": [],
+  "supertypes": []
+}
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,0 +1,16772 @@
+[
+  {
+    "type": "add_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "aggregate_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "decl_defs",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "aggregate_foreach",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "foreach",
+          "named": true
+        },
+        {
+          "type": "foreach_aggregate",
+          "named": true
+        },
+        {
+          "type": "foreach_type_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alias_assign",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alias_assignment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "function_literal_body",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alias_assignments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alias_assignment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alias_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alias_assignments",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "declarators",
+          "named": true
+        },
+        {
+          "type": "func_declarator",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alias_this",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "align_attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "allocator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "allocator_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alt_declarator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator_inner",
+          "named": true
+        },
+        {
+          "type": "alt_declarator_suffixes",
+          "named": true
+        },
+        {
+          "type": "alt_func_declarator_suffix",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "type_suffixes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alt_declarator_identifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator_suffixes",
+          "named": true
+        },
+        {
+          "type": "array_initializer",
+          "named": true
+        },
+        {
+          "type": "exp_initializer",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "struct_initializer",
+          "named": true
+        },
+        {
+          "type": "type_suffixes",
+          "named": true
+        },
+        {
+          "type": "void_initializer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alt_declarator_inner",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "alt_func_declarator_suffix",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "type_suffixes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alt_declarator_suffix",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alt_declarator_suffixes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator_suffix",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "alt_func_declarator_suffix",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "and_and_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "and_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "anon_struct_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "anon_union_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "anonymous_enum_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "anonymous_enum_members",
+          "named": true
+        },
+        {
+          "type": "enum_base_type",
+          "named": true
+        },
+        {
+          "type": "enum_members",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "anonymous_enum_member",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "anonymous_enum_members",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "anonymous_enum_member",
+          "named": true
+        },
+        {
+          "type": "enum_member",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_initializer",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "array_member_initializations",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_member_initialization",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "array_initializer",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "exp_initializer",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "struct_initializer",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_member_initializations",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array_member_initialization",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_add_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_and_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_br_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_equal_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_instruction",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "opcode",
+          "named": true
+        },
+        {
+          "type": "operands",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_instruction_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "asm_instruction",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_log_and_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_log_or_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_mul_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_or_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_primary_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        },
+        {
+          "type": "dot_identifier",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "register",
+          "named": true
+        },
+        {
+          "type": "register64",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_rel_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_shift_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "asm_instruction_list",
+          "named": true
+        },
+        {
+          "type": "function_attributes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_type_prefix",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "fundamental_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_una_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_type_prefix",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asm_xor_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "assert_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "assert_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assert_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "assign_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "assoc_array_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "key_value_pairs",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "at_attribute",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "attribute",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "attribute_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alias_assign",
+          "named": true
+        },
+        {
+          "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "alias_this",
+          "named": true
+        },
+        {
+          "type": "align_attribute",
+          "named": true
+        },
+        {
+          "type": "allocator",
+          "named": true
+        },
+        {
+          "type": "anon_struct_declaration",
+          "named": true
+        },
+        {
+          "type": "anon_union_declaration",
+          "named": true
+        },
+        {
+          "type": "anonymous_enum_declaration",
+          "named": true
+        },
+        {
+          "type": "at_attribute",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "auto_declaration",
+          "named": true
+        },
+        {
+          "type": "auto_func_declaration",
+          "named": true
+        },
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "class_template_declaration",
+          "named": true
+        },
+        {
+          "type": "conditional_declaration",
+          "named": true
+        },
+        {
+          "type": "constructor",
+          "named": true
+        },
+        {
+          "type": "constructor_template",
+          "named": true
+        },
+        {
+          "type": "deallocator",
+          "named": true
+        },
+        {
+          "type": "debug_specification",
+          "named": true
+        },
+        {
+          "type": "declaration_block",
+          "named": true
+        },
+        {
+          "type": "deprecated_attribute",
+          "named": true
+        },
+        {
+          "type": "destructor",
+          "named": true
+        },
+        {
+          "type": "empty_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "func_declaration",
+          "named": true
+        },
+        {
+          "type": "function_attribute_kwd",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_template_declaration",
+          "named": true
+        },
+        {
+          "type": "invariant",
+          "named": true
+        },
+        {
+          "type": "linkage_attribute",
+          "named": true
+        },
+        {
+          "type": "mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "postblit",
+          "named": true
+        },
+        {
+          "type": "pragma",
+          "named": true
+        },
+        {
+          "type": "property",
+          "named": true
+        },
+        {
+          "type": "shared_static_constructor",
+          "named": true
+        },
+        {
+          "type": "shared_static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_constructor",
+          "named": true
+        },
+        {
+          "type": "static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_foreach_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "template_mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "union_declaration",
+          "named": true
+        },
+        {
+          "type": "union_template_declaration",
+          "named": true
+        },
+        {
+          "type": "unit_test",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        },
+        {
+          "type": "var_declarations",
+          "named": true
+        },
+        {
+          "type": "version_specification",
+          "named": true
+        },
+        {
+          "type": "visibility_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "auto_assignment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array_initializer",
+          "named": true
+        },
+        {
+          "type": "exp_initializer",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "struct_initializer",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        },
+        {
+          "type": "void_initializer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "auto_assignments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "auto_assignment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "auto_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "auto_assignments",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "auto_func_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "func_declarator_suffix",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "base_class_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "interfaces",
+          "named": true
+        },
+        {
+          "type": "super_class_or_interface",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "base_interface_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "interfaces",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "basic_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_ctor",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "block_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "statement_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "break_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "case_range_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "first_exp",
+          "named": true
+        },
+        {
+          "type": "last_exp",
+          "named": true
+        },
+        {
+          "type": "scope_statement_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "case_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "scope_statement_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "cast_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_ctors",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "cat_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "catch",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "catch_parameter",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "catch_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "catches",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "catch",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "class_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "base_class_list",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "class_template_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "base_class_list",
+          "named": true
+        },
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "comma_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "comma_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "complement_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "conditional_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alias_assign",
+          "named": true
+        },
+        {
+          "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "alias_this",
+          "named": true
+        },
+        {
+          "type": "allocator",
+          "named": true
+        },
+        {
+          "type": "anon_struct_declaration",
+          "named": true
+        },
+        {
+          "type": "anon_union_declaration",
+          "named": true
+        },
+        {
+          "type": "anonymous_enum_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "auto_declaration",
+          "named": true
+        },
+        {
+          "type": "auto_func_declaration",
+          "named": true
+        },
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "class_template_declaration",
+          "named": true
+        },
+        {
+          "type": "conditional_declaration",
+          "named": true
+        },
+        {
+          "type": "constructor",
+          "named": true
+        },
+        {
+          "type": "constructor_template",
+          "named": true
+        },
+        {
+          "type": "deallocator",
+          "named": true
+        },
+        {
+          "type": "debug_condition",
+          "named": true
+        },
+        {
+          "type": "debug_specification",
+          "named": true
+        },
+        {
+          "type": "decl_defs",
+          "named": true
+        },
+        {
+          "type": "declaration_block",
+          "named": true
+        },
+        {
+          "type": "destructor",
+          "named": true
+        },
+        {
+          "type": "empty_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "func_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_template_declaration",
+          "named": true
+        },
+        {
+          "type": "invariant",
+          "named": true
+        },
+        {
+          "type": "mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "postblit",
+          "named": true
+        },
+        {
+          "type": "shared_static_constructor",
+          "named": true
+        },
+        {
+          "type": "shared_static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_constructor",
+          "named": true
+        },
+        {
+          "type": "static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_foreach_declaration",
+          "named": true
+        },
+        {
+          "type": "static_if_condition",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "template_mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "union_declaration",
+          "named": true
+        },
+        {
+          "type": "union_template_declaration",
+          "named": true
+        },
+        {
+          "type": "unit_test",
+          "named": true
+        },
+        {
+          "type": "var_declarations",
+          "named": true
+        },
+        {
+          "type": "version_condition",
+          "named": true
+        },
+        {
+          "type": "version_specification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "conditional_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "conditional_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "debug_condition",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "static_if_condition",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "version_condition",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constraint",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constructor",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constructor_args",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constructor_template",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "continue_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "deallocator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "debug_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "debug_specification",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "decl_defs",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "alias_assign",
+          "named": true
+        },
+        {
+          "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "alias_this",
+          "named": true
+        },
+        {
+          "type": "allocator",
+          "named": true
+        },
+        {
+          "type": "anon_struct_declaration",
+          "named": true
+        },
+        {
+          "type": "anon_union_declaration",
+          "named": true
+        },
+        {
+          "type": "anonymous_enum_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "auto_declaration",
+          "named": true
+        },
+        {
+          "type": "auto_func_declaration",
+          "named": true
+        },
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "class_template_declaration",
+          "named": true
+        },
+        {
+          "type": "conditional_declaration",
+          "named": true
+        },
+        {
+          "type": "constructor",
+          "named": true
+        },
+        {
+          "type": "constructor_template",
+          "named": true
+        },
+        {
+          "type": "deallocator",
+          "named": true
+        },
+        {
+          "type": "debug_specification",
+          "named": true
+        },
+        {
+          "type": "destructor",
+          "named": true
+        },
+        {
+          "type": "empty_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "func_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_template_declaration",
+          "named": true
+        },
+        {
+          "type": "invariant",
+          "named": true
+        },
+        {
+          "type": "mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "postblit",
+          "named": true
+        },
+        {
+          "type": "shared_static_constructor",
+          "named": true
+        },
+        {
+          "type": "shared_static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_constructor",
+          "named": true
+        },
+        {
+          "type": "static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_foreach_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "template_mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "union_declaration",
+          "named": true
+        },
+        {
+          "type": "union_template_declaration",
+          "named": true
+        },
+        {
+          "type": "unit_test",
+          "named": true
+        },
+        {
+          "type": "var_declarations",
+          "named": true
+        },
+        {
+          "type": "version_specification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "declaration_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "decl_defs",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "declaration_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "alias_assign",
+          "named": true
+        },
+        {
+          "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "anon_struct_declaration",
+          "named": true
+        },
+        {
+          "type": "anon_union_declaration",
+          "named": true
+        },
+        {
+          "type": "anonymous_enum_declaration",
+          "named": true
+        },
+        {
+          "type": "auto_declaration",
+          "named": true
+        },
+        {
+          "type": "auto_func_declaration",
+          "named": true
+        },
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "class_template_declaration",
+          "named": true
+        },
+        {
+          "type": "conditional_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "func_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_template_declaration",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_declaration",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_declaration",
+          "named": true
+        },
+        {
+          "type": "union_declaration",
+          "named": true
+        },
+        {
+          "type": "union_template_declaration",
+          "named": true
+        },
+        {
+          "type": "var_declarations",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "declarator_identifier_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator_identifier",
+          "named": true
+        },
+        {
+          "type": "var_declarator_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "declarator_initializer",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "array_initializer",
+          "named": true
+        },
+        {
+          "type": "exp_initializer",
+          "named": true
+        },
+        {
+          "type": "struct_initializer",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        },
+        {
+          "type": "void_initializer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "declarators",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "declarator_identifier_list",
+          "named": true
+        },
+        {
+          "type": "declarator_initializer",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "default_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "scope_statement_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "delete_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "deprecated_attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "destructor",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "do_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "dot_identifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "dot_identifier",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "else_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "empty_declaration",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "empty_statement",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "enum_base_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "enum_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "enum_members",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "enum_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "enum_base_type",
+          "named": true
+        },
+        {
+          "type": "enum_body",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "enum_member",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "enum_member_attributes",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "enum_member_attribute",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "enum_member_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "deprecated_attribute",
+          "named": true
+        },
+        {
+          "type": "enum_member_attribute",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "enum_members",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "enum_member",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "equal_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "exp_initializer",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "comma_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expression_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "final_switch_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "finally_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "first_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "float_literal",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "for_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "increment",
+          "named": true
+        },
+        {
+          "type": "initialize",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "test",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "foreach",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "foreach_aggregate",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "foreach_range_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "range_foreach",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "foreach_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_foreach",
+          "named": true
+        },
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "foreach_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "foreach_type_attributes",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "foreach_type_attribute",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "foreach_type_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "foreach_type_attribute",
+          "named": true
+        },
+        {
+          "type": "type_ctor",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "foreach_type_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "foreach_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "func_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "func_declarator",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "func_declarator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "func_declarator_suffix",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "type_suffixes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "func_declarator_suffix",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_attribute_kwd",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "function_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "at_attribute",
+          "named": true
+        },
+        {
+          "type": "function_attribute_kwd",
+          "named": true
+        },
+        {
+          "type": "property",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_contracts",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "in_contract_expression",
+          "named": true
+        },
+        {
+          "type": "in_statement",
+          "named": true
+        },
+        {
+          "type": "out_contract_expression",
+          "named": true
+        },
+        {
+          "type": "out_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "function_literal_body",
+          "named": true
+        },
+        {
+          "type": "function_literal_body2",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "parameter_with_attributes",
+          "named": true
+        },
+        {
+          "type": "parameter_with_member_attributes",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_literal_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_literal_body2",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "fundamental_type",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "gcc_asm_clobbers",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_clobbers",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_asm_goto_labels",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "gcc_asm_goto_labels",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_asm_instruction_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "gcc_basic_asm_instruction",
+          "named": true
+        },
+        {
+          "type": "gcc_ext_asm_instruction",
+          "named": true
+        },
+        {
+          "type": "gcc_goto_asm_instruction",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_asm_operands",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_operands",
+          "named": true
+        },
+        {
+          "type": "gcc_symbolic_name",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_asm_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function_attributes",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_instruction_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_basic_asm_instruction",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_ext_asm_instruction",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_clobbers",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_operands",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_goto_asm_instruction",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_clobbers",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_goto_labels",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_operands",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gcc_symbolic_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "goto_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "identity_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "if_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "type_ctors",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "if_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "else_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "if_condition",
+          "named": true
+        },
+        {
+          "type": "then_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "module_alias_identifier",
+          "named": true
+        },
+        {
+          "type": "module_fully_qualified_name",
+          "named": true
+        },
+        {
+          "type": "module_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_bind",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_bind_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "import_bind",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_bindings",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "import",
+          "named": true
+        },
+        {
+          "type": "import_bind_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "import_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "import_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "import",
+          "named": true
+        },
+        {
+          "type": "import_bindings",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "in_contract_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assert_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "in_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "in_out",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "in_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "increment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "index_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "initialize",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "interface",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "interface_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "base_interface_list",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "interface_template_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "base_interface_list",
+          "named": true
+        },
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "interfaces",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "interface",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "invariant",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assert_arguments",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "is_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameter_list",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_specialization",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_value_pair",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "key_expression",
+          "named": true
+        },
+        {
+          "type": "value_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_value_pairs",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "key_value_pair",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "keyword",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "labeled_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_block_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "last_exp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "linkage_attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "linkage_type",
+          "named": true
+        },
+        {
+          "type": "namespace_list",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "linkage_type",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "lwr_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "member_function_attribute",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "member_function_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "at_attribute",
+          "named": true
+        },
+        {
+          "type": "function_attribute_kwd",
+          "named": true
+        },
+        {
+          "type": "member_function_attribute",
+          "named": true
+        },
+        {
+          "type": "property",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "missing_function_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "function_contracts",
+          "named": true
+        },
+        {
+          "type": "in_contract_expression",
+          "named": true
+        },
+        {
+          "type": "in_statement",
+          "named": true
+        },
+        {
+          "type": "out_contract_expression",
+          "named": true
+        },
+        {
+          "type": "out_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_qualified_identifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_template_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "mixin_qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "decl_defs",
+          "named": true
+        },
+        {
+          "type": "module_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_alias_identifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "deprecated_attribute",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "module_attributes",
+          "named": true
+        },
+        {
+          "type": "module_fully_qualified_name",
+          "named": true
+        },
+        {
+          "type": "module_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_fully_qualified_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "module_name",
+          "named": true
+        },
+        {
+          "type": "packages",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mul_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "namespace_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "new_anon_class_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "allocator_arguments",
+          "named": true
+        },
+        {
+          "type": "constructor_args",
+          "named": true
+        },
+        {
+          "type": "interfaces",
+          "named": true
+        },
+        {
+          "type": "super_class_or_interface",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "new_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "allocator_arguments",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "opcode",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "operand",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_add_exp",
+          "named": true
+        },
+        {
+          "type": "asm_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_br_exp",
+          "named": true
+        },
+        {
+          "type": "asm_equal_exp",
+          "named": true
+        },
+        {
+          "type": "asm_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_and_exp",
+          "named": true
+        },
+        {
+          "type": "asm_log_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_mul_exp",
+          "named": true
+        },
+        {
+          "type": "asm_or_exp",
+          "named": true
+        },
+        {
+          "type": "asm_primary_exp",
+          "named": true
+        },
+        {
+          "type": "asm_rel_exp",
+          "named": true
+        },
+        {
+          "type": "asm_shift_exp",
+          "named": true
+        },
+        {
+          "type": "asm_una_exp",
+          "named": true
+        },
+        {
+          "type": "asm_xor_exp",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "operands",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "operand",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "or_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "or_or_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "out_contract_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "assert_arguments",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "out_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "package_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "packages",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "package_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "parameter_attributes",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parameter_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "in_out",
+          "named": true
+        },
+        {
+          "type": "type_ctor",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parameter_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "variadic_arguments_attributes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parameter_with_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function_attributes",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parameter_with_member_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parameters",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "parameter_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "postblit",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "postfix_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "new_anon_class_expression",
+          "named": true
+        },
+        {
+          "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "type_ctors",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pow_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pragma",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pragma_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "primary_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "array_literal",
+          "named": true
+        },
+        {
+          "type": "assert_expression",
+          "named": true
+        },
+        {
+          "type": "assoc_array_literal",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "function_literal_body",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "import_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "is_expression",
+          "named": true
+        },
+        {
+          "type": "mixin_expression",
+          "named": true
+        },
+        {
+          "type": "new_anon_class_expression",
+          "named": true
+        },
+        {
+          "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "special_keyword",
+          "named": true
+        },
+        {
+          "type": "string_literals",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_ctor",
+          "named": true
+        },
+        {
+          "type": "typeid_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "property",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "qualified_identifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "range_foreach",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "foreach",
+          "named": true
+        },
+        {
+          "type": "foreach_type",
+          "named": true
+        },
+        {
+          "type": "lwr_expression",
+          "named": true
+        },
+        {
+          "type": "upr_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "register",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "register64",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "rel_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "return_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "scope_block_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "scope_guard_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_block_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "scope_statement_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "statement_list_no_case_no_default",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "shared_static_constructor",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "shared_static_destructor",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "shift_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "shortened_function_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "function_contracts",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_contract_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "out_contract_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "slice",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "slice_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "source_file",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "byte_order_mark",
+          "named": true
+        },
+        {
+          "type": "module",
+          "named": true
+        },
+        {
+          "type": "shebang",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "special_keyword",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "special_token_sequence",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "filespec",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "specified_function_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "function_contracts",
+          "named": true
+        },
+        {
+          "type": "in_contract_expression",
+          "named": true
+        },
+        {
+          "type": "in_statement",
+          "named": true
+        },
+        {
+          "type": "out_contract_expression",
+          "named": true
+        },
+        {
+          "type": "out_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "statement_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_block_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "statement_list_no_case_no_default",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_block_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_assert",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assert_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_constructor",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_destructor",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "missing_function_body",
+          "named": true
+        },
+        {
+          "type": "shortened_function_body",
+          "named": true
+        },
+        {
+          "type": "specified_function_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_foreach",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_foreach",
+          "named": true
+        },
+        {
+          "type": "range_foreach",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_foreach_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alias_assign",
+          "named": true
+        },
+        {
+          "type": "alias_declaration",
+          "named": true
+        },
+        {
+          "type": "alias_this",
+          "named": true
+        },
+        {
+          "type": "allocator",
+          "named": true
+        },
+        {
+          "type": "anon_struct_declaration",
+          "named": true
+        },
+        {
+          "type": "anon_union_declaration",
+          "named": true
+        },
+        {
+          "type": "anonymous_enum_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "auto_declaration",
+          "named": true
+        },
+        {
+          "type": "auto_func_declaration",
+          "named": true
+        },
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "class_template_declaration",
+          "named": true
+        },
+        {
+          "type": "conditional_declaration",
+          "named": true
+        },
+        {
+          "type": "constructor",
+          "named": true
+        },
+        {
+          "type": "constructor_template",
+          "named": true
+        },
+        {
+          "type": "deallocator",
+          "named": true
+        },
+        {
+          "type": "debug_specification",
+          "named": true
+        },
+        {
+          "type": "decl_defs",
+          "named": true
+        },
+        {
+          "type": "declaration_block",
+          "named": true
+        },
+        {
+          "type": "destructor",
+          "named": true
+        },
+        {
+          "type": "empty_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "func_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_template_declaration",
+          "named": true
+        },
+        {
+          "type": "invariant",
+          "named": true
+        },
+        {
+          "type": "mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "postblit",
+          "named": true
+        },
+        {
+          "type": "shared_static_constructor",
+          "named": true
+        },
+        {
+          "type": "shared_static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_constructor",
+          "named": true
+        },
+        {
+          "type": "static_destructor",
+          "named": true
+        },
+        {
+          "type": "static_foreach",
+          "named": true
+        },
+        {
+          "type": "static_foreach_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_declaration",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "template_mixin_declaration",
+          "named": true
+        },
+        {
+          "type": "union_declaration",
+          "named": true
+        },
+        {
+          "type": "union_template_declaration",
+          "named": true
+        },
+        {
+          "type": "unit_test",
+          "named": true
+        },
+        {
+          "type": "var_declarations",
+          "named": true
+        },
+        {
+          "type": "version_specification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_foreach_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "static_if_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "storage_class",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "storage_classes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "align_attribute",
+          "named": true
+        },
+        {
+          "type": "at_attribute",
+          "named": true
+        },
+        {
+          "type": "linkage_attribute",
+          "named": true
+        },
+        {
+          "type": "property",
+          "named": true
+        },
+        {
+          "type": "storage_class",
+          "named": true
+        },
+        {
+          "type": "user_defined_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string_literals",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_initializer",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "struct_member_initializers",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_member_initializer",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array_initializer",
+          "named": true
+        },
+        {
+          "type": "exp_initializer",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "struct_initializer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_member_initializers",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "struct_member_initializer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_template_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "super_class_or_interface",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "switch_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "symbol",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "symbol_tail",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "symbol_tail",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "symbol_tail",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "synchronized_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_alias_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "template_alias_parameter_default",
+          "named": true
+        },
+        {
+          "type": "template_alias_parameter_specialization",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_alias_parameter_default",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_alias_parameter_specialization",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "template_argument_list",
+          "named": true
+        },
+        {
+          "type": "template_single_argument",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "decl_defs",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_instance",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_mixin",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "mixin_template_name",
+          "named": true
+        },
+        {
+          "type": "template_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_mixin_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "decl_defs",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_parameter_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "template_alias_parameter",
+          "named": true
+        },
+        {
+          "type": "template_sequence_parameter",
+          "named": true
+        },
+        {
+          "type": "template_this_parameter",
+          "named": true
+        },
+        {
+          "type": "template_type_parameter",
+          "named": true
+        },
+        {
+          "type": "template_value_parameter",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_parameters",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "template_parameter_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_sequence_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_single_argument",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "special_keyword",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_this_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "template_type_parameter",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_type_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_type_parameter_default",
+          "named": true
+        },
+        {
+          "type": "template_type_parameter_specialization",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_type_parameter_default",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_type_parameter_specialization",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_value_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alt_declarator",
+          "named": true
+        },
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "template_value_parameter_default",
+          "named": true
+        },
+        {
+          "type": "template_value_parameter_specialization",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "var_declarator",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_value_parameter_default",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "special_keyword",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_value_parameter_specialization",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "test",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "then_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "throw_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "token_no_braces",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "alternate_wysiwyg_string",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "delimited_string",
+          "named": true
+        },
+        {
+          "type": "double_quoted_string",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "hex_string",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "token_string",
+          "named": true
+        },
+        {
+          "type": "wysiwyg_string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "token_string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "token_string_tokens",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "token_string_token",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "token_string_tokens",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "token_string_tokens",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "token_no_braces",
+          "named": true
+        },
+        {
+          "type": "token_string_token",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "traits_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "traits_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "traits_arguments",
+          "named": true
+        },
+        {
+          "type": "traits_keyword",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "traits_keyword",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "try_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "catches",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "finally_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "type_ctors",
+          "named": true
+        },
+        {
+          "type": "type_suffixes",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_ctor",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "type_ctors",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_ctor",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_specialization",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_suffix",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "function_attributes",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "member_function_attributes",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "parameters",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_suffixes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_suffix",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "typeid_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "typeof",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unary_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "union_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "union_template_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "aggregate_body",
+          "named": true
+        },
+        {
+          "type": "constraint",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unit_test",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "upr_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "user_defined_attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "value_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_and_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "assign_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "or_expression",
+          "named": true
+        },
+        {
+          "type": "or_or_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "var_declarations",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "basic_type",
+          "named": true
+        },
+        {
+          "type": "declarators",
+          "named": true
+        },
+        {
+          "type": "fundamental_type",
+          "named": true
+        },
+        {
+          "type": "mixin_type",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "storage_classes",
+          "named": true
+        },
+        {
+          "type": "traits_expression",
+          "named": true
+        },
+        {
+          "type": "typeof",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "var_declarator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "type_suffixes",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "var_declarator_identifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array_initializer",
+          "named": true
+        },
+        {
+          "type": "exp_initializer",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "struct_initializer",
+          "named": true
+        },
+        {
+          "type": "template_parameters",
+          "named": true
+        },
+        {
+          "type": "void_initializer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "variadic_arguments_attribute",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "variadic_arguments_attributes",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "variadic_arguments_attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "vector",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "vector_base_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "vector_base_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "version_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "version_specification",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "visibility_attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "qualified_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "void_initializer",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "while_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_condition",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "with_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm_statement",
+          "named": true
+        },
+        {
+          "type": "block_statement",
+          "named": true
+        },
+        {
+          "type": "break_statement",
+          "named": true
+        },
+        {
+          "type": "case_range_statement",
+          "named": true
+        },
+        {
+          "type": "case_statement",
+          "named": true
+        },
+        {
+          "type": "conditional_statement",
+          "named": true
+        },
+        {
+          "type": "continue_statement",
+          "named": true
+        },
+        {
+          "type": "declaration_statement",
+          "named": true
+        },
+        {
+          "type": "default_statement",
+          "named": true
+        },
+        {
+          "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_statement",
+          "named": true
+        },
+        {
+          "type": "final_switch_statement",
+          "named": true
+        },
+        {
+          "type": "for_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_range_statement",
+          "named": true
+        },
+        {
+          "type": "foreach_statement",
+          "named": true
+        },
+        {
+          "type": "gcc_asm_statement",
+          "named": true
+        },
+        {
+          "type": "goto_statement",
+          "named": true
+        },
+        {
+          "type": "if_statement",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
+          "type": "labeled_statement",
+          "named": true
+        },
+        {
+          "type": "mixin_statement",
+          "named": true
+        },
+        {
+          "type": "pragma_statement",
+          "named": true
+        },
+        {
+          "type": "return_statement",
+          "named": true
+        },
+        {
+          "type": "scope_guard_statement",
+          "named": true
+        },
+        {
+          "type": "static_assert",
+          "named": true
+        },
+        {
+          "type": "static_foreach_statement",
+          "named": true
+        },
+        {
+          "type": "switch_statement",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "synchronized_statement",
+          "named": true
+        },
+        {
+          "type": "template_instance",
+          "named": true
+        },
+        {
+          "type": "template_mixin",
+          "named": true
+        },
+        {
+          "type": "throw_statement",
+          "named": true
+        },
+        {
+          "type": "try_statement",
+          "named": true
+        },
+        {
+          "type": "while_statement",
+          "named": true
+        },
+        {
+          "type": "with_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "xor_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "add_expression",
+          "named": true
+        },
+        {
+          "type": "and_expression",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "cat_expression",
+          "named": true
+        },
+        {
+          "type": "complement_expression",
+          "named": true
+        },
+        {
+          "type": "delete_expression",
+          "named": true
+        },
+        {
+          "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "identity_expression",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "index_expression",
+          "named": true
+        },
+        {
+          "type": "mul_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "pow_expression",
+          "named": true
+        },
+        {
+          "type": "primary_expression",
+          "named": true
+        },
+        {
+          "type": "rel_expression",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "slice_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "xor_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "!",
+    "named": false
+  },
+  {
+    "type": "!=",
+    "named": false
+  },
+  {
+    "type": "#",
+    "named": false
+  },
+  {
+    "type": "$",
+    "named": false
+  },
+  {
+    "type": "%",
+    "named": false
+  },
+  {
+    "type": "%=",
+    "named": false
+  },
+  {
+    "type": "&",
+    "named": false
+  },
+  {
+    "type": "&&",
+    "named": false
+  },
+  {
+    "type": "&=",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": "*=",
+    "named": false
+  },
+  {
+    "type": "+",
+    "named": false
+  },
+  {
+    "type": "++",
+    "named": false
+  },
+  {
+    "type": "+=",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": "-",
+    "named": false
+  },
+  {
+    "type": "--",
+    "named": false
+  },
+  {
+    "type": "-=",
+    "named": false
+  },
+  {
+    "type": ".",
+    "named": false
+  },
+  {
+    "type": "..",
+    "named": false
+  },
+  {
+    "type": "...",
+    "named": false
+  },
+  {
+    "type": "/",
+    "named": false
+  },
+  {
+    "type": "/=",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": ";",
+    "named": false
+  },
+  {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "<<",
+    "named": false
+  },
+  {
+    "type": "<<=",
+    "named": false
+  },
+  {
+    "type": "<=",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": "==",
+    "named": false
+  },
+  {
+    "type": "=>",
+    "named": false
+  },
+  {
+    "type": ">",
+    "named": false
+  },
+  {
+    "type": ">=",
+    "named": false
+  },
+  {
+    "type": ">>",
+    "named": false
+  },
+  {
+    "type": ">>=",
+    "named": false
+  },
+  {
+    "type": ">>>",
+    "named": false
+  },
+  {
+    "type": ">>>=",
+    "named": false
+  },
+  {
+    "type": "?",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "AH",
+    "named": false
+  },
+  {
+    "type": "AL",
+    "named": false
+  },
+  {
+    "type": "AX",
+    "named": false
+  },
+  {
+    "type": "BH",
+    "named": false
+  },
+  {
+    "type": "BL",
+    "named": false
+  },
+  {
+    "type": "BP",
+    "named": false
+  },
+  {
+    "type": "BPL",
+    "named": false
+  },
+  {
+    "type": "BX",
+    "named": false
+  },
+  {
+    "type": "C",
+    "named": false
+  },
+  {
+    "type": "C++",
+    "named": false
+  },
+  {
+    "type": "CH",
+    "named": false
+  },
+  {
+    "type": "CL",
+    "named": false
+  },
+  {
+    "type": "CR0",
+    "named": false
+  },
+  {
+    "type": "CR2",
+    "named": false
+  },
+  {
+    "type": "CR3",
+    "named": false
+  },
+  {
+    "type": "CR4",
+    "named": false
+  },
+  {
+    "type": "CS",
+    "named": false
+  },
+  {
+    "type": "CX",
+    "named": false
+  },
+  {
+    "type": "D",
+    "named": false
+  },
+  {
+    "type": "DH",
+    "named": false
+  },
+  {
+    "type": "DI",
+    "named": false
+  },
+  {
+    "type": "DIL",
+    "named": false
+  },
+  {
+    "type": "DL",
+    "named": false
+  },
+  {
+    "type": "DR0",
+    "named": false
+  },
+  {
+    "type": "DR1",
+    "named": false
+  },
+  {
+    "type": "DR2",
+    "named": false
+  },
+  {
+    "type": "DR3",
+    "named": false
+  },
+  {
+    "type": "DR6",
+    "named": false
+  },
+  {
+    "type": "DR7",
+    "named": false
+  },
+  {
+    "type": "DS",
+    "named": false
+  },
+  {
+    "type": "DX",
+    "named": false
+  },
+  {
+    "type": "EAX",
+    "named": false
+  },
+  {
+    "type": "EBP",
+    "named": false
+  },
+  {
+    "type": "EBX",
+    "named": false
+  },
+  {
+    "type": "ECX",
+    "named": false
+  },
+  {
+    "type": "EDI",
+    "named": false
+  },
+  {
+    "type": "EDX",
+    "named": false
+  },
+  {
+    "type": "ES",
+    "named": false
+  },
+  {
+    "type": "ESI",
+    "named": false
+  },
+  {
+    "type": "ESP",
+    "named": false
+  },
+  {
+    "type": "FS",
+    "named": false
+  },
+  {
+    "type": "GS",
+    "named": false
+  },
+  {
+    "type": "MM0",
+    "named": false
+  },
+  {
+    "type": "MM1",
+    "named": false
+  },
+  {
+    "type": "MM2",
+    "named": false
+  },
+  {
+    "type": "MM3",
+    "named": false
+  },
+  {
+    "type": "MM4",
+    "named": false
+  },
+  {
+    "type": "MM5",
+    "named": false
+  },
+  {
+    "type": "MM6",
+    "named": false
+  },
+  {
+    "type": "MM7",
+    "named": false
+  },
+  {
+    "type": "Objective-C",
+    "named": false
+  },
+  {
+    "type": "R10",
+    "named": false
+  },
+  {
+    "type": "R10B",
+    "named": false
+  },
+  {
+    "type": "R10D",
+    "named": false
+  },
+  {
+    "type": "R10W",
+    "named": false
+  },
+  {
+    "type": "R11",
+    "named": false
+  },
+  {
+    "type": "R11B",
+    "named": false
+  },
+  {
+    "type": "R11D",
+    "named": false
+  },
+  {
+    "type": "R11W",
+    "named": false
+  },
+  {
+    "type": "R12",
+    "named": false
+  },
+  {
+    "type": "R12B",
+    "named": false
+  },
+  {
+    "type": "R12D",
+    "named": false
+  },
+  {
+    "type": "R12W",
+    "named": false
+  },
+  {
+    "type": "R13",
+    "named": false
+  },
+  {
+    "type": "R13B",
+    "named": false
+  },
+  {
+    "type": "R13D",
+    "named": false
+  },
+  {
+    "type": "R13W",
+    "named": false
+  },
+  {
+    "type": "R14",
+    "named": false
+  },
+  {
+    "type": "R14B",
+    "named": false
+  },
+  {
+    "type": "R14D",
+    "named": false
+  },
+  {
+    "type": "R14W",
+    "named": false
+  },
+  {
+    "type": "R15",
+    "named": false
+  },
+  {
+    "type": "R15B",
+    "named": false
+  },
+  {
+    "type": "R15D",
+    "named": false
+  },
+  {
+    "type": "R15W",
+    "named": false
+  },
+  {
+    "type": "R8",
+    "named": false
+  },
+  {
+    "type": "R8B",
+    "named": false
+  },
+  {
+    "type": "R8D",
+    "named": false
+  },
+  {
+    "type": "R8W",
+    "named": false
+  },
+  {
+    "type": "R9",
+    "named": false
+  },
+  {
+    "type": "R9B",
+    "named": false
+  },
+  {
+    "type": "R9D",
+    "named": false
+  },
+  {
+    "type": "R9W",
+    "named": false
+  },
+  {
+    "type": "RAX",
+    "named": false
+  },
+  {
+    "type": "RBP",
+    "named": false
+  },
+  {
+    "type": "RBX",
+    "named": false
+  },
+  {
+    "type": "RCX",
+    "named": false
+  },
+  {
+    "type": "RDI",
+    "named": false
+  },
+  {
+    "type": "RDX",
+    "named": false
+  },
+  {
+    "type": "RSI",
+    "named": false
+  },
+  {
+    "type": "RSP",
+    "named": false
+  },
+  {
+    "type": "SI",
+    "named": false
+  },
+  {
+    "type": "SIL",
+    "named": false
+  },
+  {
+    "type": "SP",
+    "named": false
+  },
+  {
+    "type": "SPL",
+    "named": false
+  },
+  {
+    "type": "SS",
+    "named": false
+  },
+  {
+    "type": "ST",
+    "named": false
+  },
+  {
+    "type": "ST(0)",
+    "named": false
+  },
+  {
+    "type": "ST(1)",
+    "named": false
+  },
+  {
+    "type": "ST(2)",
+    "named": false
+  },
+  {
+    "type": "ST(3)",
+    "named": false
+  },
+  {
+    "type": "ST(4)",
+    "named": false
+  },
+  {
+    "type": "ST(5)",
+    "named": false
+  },
+  {
+    "type": "ST(6)",
+    "named": false
+  },
+  {
+    "type": "ST(7)",
+    "named": false
+  },
+  {
+    "type": "System",
+    "named": false
+  },
+  {
+    "type": "TR3",
+    "named": false
+  },
+  {
+    "type": "TR4",
+    "named": false
+  },
+  {
+    "type": "TR5",
+    "named": false
+  },
+  {
+    "type": "TR6",
+    "named": false
+  },
+  {
+    "type": "TR7",
+    "named": false
+  },
+  {
+    "type": "Windows",
+    "named": false
+  },
+  {
+    "type": "XMM0",
+    "named": false
+  },
+  {
+    "type": "XMM1",
+    "named": false
+  },
+  {
+    "type": "XMM10",
+    "named": false
+  },
+  {
+    "type": "XMM11",
+    "named": false
+  },
+  {
+    "type": "XMM12",
+    "named": false
+  },
+  {
+    "type": "XMM13",
+    "named": false
+  },
+  {
+    "type": "XMM14",
+    "named": false
+  },
+  {
+    "type": "XMM15",
+    "named": false
+  },
+  {
+    "type": "XMM2",
+    "named": false
+  },
+  {
+    "type": "XMM3",
+    "named": false
+  },
+  {
+    "type": "XMM4",
+    "named": false
+  },
+  {
+    "type": "XMM5",
+    "named": false
+  },
+  {
+    "type": "XMM6",
+    "named": false
+  },
+  {
+    "type": "XMM7",
+    "named": false
+  },
+  {
+    "type": "XMM8",
+    "named": false
+  },
+  {
+    "type": "XMM9",
+    "named": false
+  },
+  {
+    "type": "YMM0",
+    "named": false
+  },
+  {
+    "type": "YMM1",
+    "named": false
+  },
+  {
+    "type": "YMM10",
+    "named": false
+  },
+  {
+    "type": "YMM11",
+    "named": false
+  },
+  {
+    "type": "YMM12",
+    "named": false
+  },
+  {
+    "type": "YMM13",
+    "named": false
+  },
+  {
+    "type": "YMM14",
+    "named": false
+  },
+  {
+    "type": "YMM15",
+    "named": false
+  },
+  {
+    "type": "YMM2",
+    "named": false
+  },
+  {
+    "type": "YMM3",
+    "named": false
+  },
+  {
+    "type": "YMM4",
+    "named": false
+  },
+  {
+    "type": "YMM5",
+    "named": false
+  },
+  {
+    "type": "YMM6",
+    "named": false
+  },
+  {
+    "type": "YMM7",
+    "named": false
+  },
+  {
+    "type": "YMM8",
+    "named": false
+  },
+  {
+    "type": "YMM9",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "^",
+    "named": false
+  },
+  {
+    "type": "^=",
+    "named": false
+  },
+  {
+    "type": "^^",
+    "named": false
+  },
+  {
+    "type": "^^=",
+    "named": false
+  },
+  {
+    "type": "__FILE_FULL_PATH__",
+    "named": false
+  },
+  {
+    "type": "__FILE__",
+    "named": false
+  },
+  {
+    "type": "__FUNCTION__",
+    "named": false
+  },
+  {
+    "type": "__LINE__",
+    "named": false
+  },
+  {
+    "type": "__LOCAL_SIZE",
+    "named": false
+  },
+  {
+    "type": "__MODULE__",
+    "named": false
+  },
+  {
+    "type": "__PRETTY_FUNCTION__",
+    "named": false
+  },
+  {
+    "type": "__gshared",
+    "named": false
+  },
+  {
+    "type": "__parameters",
+    "named": false
+  },
+  {
+    "type": "__traits",
+    "named": false
+  },
+  {
+    "type": "__vector",
+    "named": false
+  },
+  {
+    "type": "_actually_a_float_literal_without_its_trailing_period",
+    "named": false
+  },
+  {
+    "type": "abstract",
+    "named": false
+  },
+  {
+    "type": "alias",
+    "named": false
+  },
+  {
+    "type": "align",
+    "named": false
+  },
+  {
+    "type": "allMembers",
+    "named": false
+  },
+  {
+    "type": "alternate_wysiwyg_string",
+    "named": true
+  },
+  {
+    "type": "asm",
+    "named": false
+  },
+  {
+    "type": "assert",
+    "named": false
+  },
+  {
+    "type": "auto",
+    "named": false
+  },
+  {
+    "type": "block_comment",
+    "named": true
+  },
+  {
+    "type": "body",
+    "named": false
+  },
+  {
+    "type": "bool",
+    "named": false
+  },
+  {
+    "type": "break",
+    "named": false
+  },
+  {
+    "type": "byte",
+    "named": false
+  },
+  {
+    "type": "byte_order_mark",
+    "named": true
+  },
+  {
+    "type": "case",
+    "named": false
+  },
+  {
+    "type": "cast",
+    "named": false
+  },
+  {
+    "type": "catch",
+    "named": false
+  },
+  {
+    "type": "cdouble",
+    "named": false
+  },
+  {
+    "type": "cent",
+    "named": false
+  },
+  {
+    "type": "cfloat",
+    "named": false
+  },
+  {
+    "type": "char",
+    "named": false
+  },
+  {
+    "type": "character_literal",
+    "named": true
+  },
+  {
+    "type": "child",
+    "named": false
+  },
+  {
+    "type": "class",
+    "named": false
+  },
+  {
+    "type": "classInstanceSize",
+    "named": false
+  },
+  {
+    "type": "compiles",
+    "named": false
+  },
+  {
+    "type": "const",
+    "named": false
+  },
+  {
+    "type": "continue",
+    "named": false
+  },
+  {
+    "type": "creal",
+    "named": false
+  },
+  {
+    "type": "db",
+    "named": false
+  },
+  {
+    "type": "dchar",
+    "named": false
+  },
+  {
+    "type": "dd",
+    "named": false
+  },
+  {
+    "type": "de",
+    "named": false
+  },
+  {
+    "type": "debug",
+    "named": false
+  },
+  {
+    "type": "default",
+    "named": false
+  },
+  {
+    "type": "delegate",
+    "named": false
+  },
+  {
+    "type": "delete",
+    "named": false
+  },
+  {
+    "type": "delimited_string",
+    "named": true
+  },
+  {
+    "type": "deprecated",
+    "named": false
+  },
+  {
+    "type": "derivedMembers",
+    "named": false
+  },
+  {
+    "type": "df",
+    "named": false
+  },
+  {
+    "type": "di",
+    "named": false
+  },
+  {
+    "type": "disable",
+    "named": false
+  },
+  {
+    "type": "dl",
+    "named": false
+  },
+  {
+    "type": "do",
+    "named": false
+  },
+  {
+    "type": "double",
+    "named": false
+  },
+  {
+    "type": "double_quoted_string",
+    "named": true
+  },
+  {
+    "type": "dq",
+    "named": false
+  },
+  {
+    "type": "ds",
+    "named": false
+  },
+  {
+    "type": "dw",
+    "named": false
+  },
+  {
+    "type": "dword",
+    "named": false
+  },
+  {
+    "type": "else",
+    "named": false
+  },
+  {
+    "type": "enum",
+    "named": false
+  },
+  {
+    "type": "even",
+    "named": false
+  },
+  {
+    "type": "exit",
+    "named": false
+  },
+  {
+    "type": "export",
+    "named": false
+  },
+  {
+    "type": "extern",
+    "named": false
+  },
+  {
+    "type": "failure",
+    "named": false
+  },
+  {
+    "type": "false",
+    "named": false
+  },
+  {
+    "type": "far",
+    "named": false
+  },
+  {
+    "type": "filespec",
+    "named": true
+  },
+  {
+    "type": "final",
+    "named": false
+  },
+  {
+    "type": "finally",
+    "named": false
+  },
+  {
+    "type": "float",
+    "named": false
+  },
+  {
+    "type": "for",
+    "named": false
+  },
+  {
+    "type": "foreach",
+    "named": false
+  },
+  {
+    "type": "foreach_reverse",
+    "named": false
+  },
+  {
+    "type": "function",
+    "named": false
+  },
+  {
+    "type": "getAliasThis",
+    "named": false
+  },
+  {
+    "type": "getAttributes",
+    "named": false
+  },
+  {
+    "type": "getCppNamespaces",
+    "named": false
+  },
+  {
+    "type": "getFunctionAttributes",
+    "named": false
+  },
+  {
+    "type": "getFunctionVariadicStyle",
+    "named": false
+  },
+  {
+    "type": "getLinkage",
+    "named": false
+  },
+  {
+    "type": "getLocation",
+    "named": false
+  },
+  {
+    "type": "getMember",
+    "named": false
+  },
+  {
+    "type": "getOverloads",
+    "named": false
+  },
+  {
+    "type": "getParameterStorageClasses",
+    "named": false
+  },
+  {
+    "type": "getPointerBitmap",
+    "named": false
+  },
+  {
+    "type": "getProtection",
+    "named": false
+  },
+  {
+    "type": "getTargetInfo",
+    "named": false
+  },
+  {
+    "type": "getUnitTests",
+    "named": false
+  },
+  {
+    "type": "getVirtualFunctions",
+    "named": false
+  },
+  {
+    "type": "getVirtualIndex",
+    "named": false
+  },
+  {
+    "type": "getVirtualMethods",
+    "named": false
+  },
+  {
+    "type": "getVisibility",
+    "named": false
+  },
+  {
+    "type": "goto",
+    "named": false
+  },
+  {
+    "type": "hasCopyConstructor",
+    "named": false
+  },
+  {
+    "type": "hasMember",
+    "named": false
+  },
+  {
+    "type": "hasPostblit",
+    "named": false
+  },
+  {
+    "type": "hex_string",
+    "named": true
+  },
+  {
+    "type": "identifier",
+    "named": false
+  },
+  {
+    "type": "identifier",
+    "named": true
+  },
+  {
+    "type": "idouble",
+    "named": false
+  },
+  {
+    "type": "if",
+    "named": false
+  },
+  {
+    "type": "ifloat",
+    "named": false
+  },
+  {
+    "type": "immutable",
+    "named": false
+  },
+  {
+    "type": "import",
+    "named": false
+  },
+  {
+    "type": "in",
+    "named": false
+  },
+  {
+    "type": "inout",
+    "named": false
+  },
+  {
+    "type": "int",
+    "named": false
+  },
+  {
+    "type": "integer_literal",
+    "named": true
+  },
+  {
+    "type": "interface",
+    "named": false
+  },
+  {
+    "type": "invariant",
+    "named": false
+  },
+  {
+    "type": "ireal",
+    "named": false
+  },
+  {
+    "type": "is",
+    "named": false
+  },
+  {
+    "type": "isAbstractClass",
+    "named": false
+  },
+  {
+    "type": "isAbstractFunction",
+    "named": false
+  },
+  {
+    "type": "isArithmetic",
+    "named": false
+  },
+  {
+    "type": "isAssociativeArray",
+    "named": false
+  },
+  {
+    "type": "isCopyable",
+    "named": false
+  },
+  {
+    "type": "isDeprecated",
+    "named": false
+  },
+  {
+    "type": "isDisabled",
+    "named": false
+  },
+  {
+    "type": "isFinalClass",
+    "named": false
+  },
+  {
+    "type": "isFinalFunction",
+    "named": false
+  },
+  {
+    "type": "isFloating",
+    "named": false
+  },
+  {
+    "type": "isFuture",
+    "named": false
+  },
+  {
+    "type": "isIntegral",
+    "named": false
+  },
+  {
+    "type": "isLazy",
+    "named": false
+  },
+  {
+    "type": "isModule",
+    "named": false
+  },
+  {
+    "type": "isNested",
+    "named": false
+  },
+  {
+    "type": "isOut",
+    "named": false
+  },
+  {
+    "type": "isOverrideFunction",
+    "named": false
+  },
+  {
+    "type": "isPOD",
+    "named": false
+  },
+  {
+    "type": "isPackage",
+    "named": false
+  },
+  {
+    "type": "isRef",
+    "named": false
+  },
+  {
+    "type": "isReturnOnStack",
+    "named": false
+  },
+  {
+    "type": "isSame",
+    "named": false
+  },
+  {
+    "type": "isScalar",
+    "named": false
+  },
+  {
+    "type": "isStaticArray",
+    "named": false
+  },
+  {
+    "type": "isStaticFunction",
+    "named": false
+  },
+  {
+    "type": "isTemplate",
+    "named": false
+  },
+  {
+    "type": "isUnsigned",
+    "named": false
+  },
+  {
+    "type": "isVirtualFunction",
+    "named": false
+  },
+  {
+    "type": "isVirtualMethod",
+    "named": false
+  },
+  {
+    "type": "isZeroInit",
+    "named": false
+  },
+  {
+    "type": "lazy",
+    "named": false
+  },
+  {
+    "type": "line",
+    "named": false
+  },
+  {
+    "type": "line_comment",
+    "named": true
+  },
+  {
+    "type": "live",
+    "named": false
+  },
+  {
+    "type": "long",
+    "named": false
+  },
+  {
+    "type": "macro",
+    "named": false
+  },
+  {
+    "type": "mixin",
+    "named": false
+  },
+  {
+    "type": "module",
+    "named": false
+  },
+  {
+    "type": "naked",
+    "named": false
+  },
+  {
+    "type": "near",
+    "named": false
+  },
+  {
+    "type": "nesting_block_comment",
+    "named": true
+  },
+  {
+    "type": "new",
+    "named": false
+  },
+  {
+    "type": "nogc",
+    "named": false
+  },
+  {
+    "type": "nothrow",
+    "named": false
+  },
+  {
+    "type": "null",
+    "named": false
+  },
+  {
+    "type": "offsetof",
+    "named": false
+  },
+  {
+    "type": "out",
+    "named": false
+  },
+  {
+    "type": "override",
+    "named": false
+  },
+  {
+    "type": "package",
+    "named": false
+  },
+  {
+    "type": "parent",
+    "named": false
+  },
+  {
+    "type": "pragma",
+    "named": false
+  },
+  {
+    "type": "private",
+    "named": false
+  },
+  {
+    "type": "property",
+    "named": false
+  },
+  {
+    "type": "protected",
+    "named": false
+  },
+  {
+    "type": "ptr",
+    "named": false
+  },
+  {
+    "type": "public",
+    "named": false
+  },
+  {
+    "type": "pure",
+    "named": false
+  },
+  {
+    "type": "qword",
+    "named": false
+  },
+  {
+    "type": "q{",
+    "named": false
+  },
+  {
+    "type": "real",
+    "named": false
+  },
+  {
+    "type": "ref",
+    "named": false
+  },
+  {
+    "type": "return",
+    "named": false
+  },
+  {
+    "type": "safe",
+    "named": false
+  },
+  {
+    "type": "scope",
+    "named": false
+  },
+  {
+    "type": "seg",
+    "named": false
+  },
+  {
+    "type": "shared",
+    "named": false
+  },
+  {
+    "type": "shebang",
+    "named": true
+  },
+  {
+    "type": "short",
+    "named": false
+  },
+  {
+    "type": "static",
+    "named": false
+  },
+  {
+    "type": "struct",
+    "named": false
+  },
+  {
+    "type": "success",
+    "named": false
+  },
+  {
+    "type": "super",
+    "named": false
+  },
+  {
+    "type": "switch",
+    "named": false
+  },
+  {
+    "type": "synchronized",
+    "named": false
+  },
+  {
+    "type": "system",
+    "named": false
+  },
+  {
+    "type": "template",
+    "named": false
+  },
+  {
+    "type": "this",
+    "named": false
+  },
+  {
+    "type": "throw",
+    "named": false
+  },
+  {
+    "type": "toType",
+    "named": false
+  },
+  {
+    "type": "true",
+    "named": false
+  },
+  {
+    "type": "trusted",
+    "named": false
+  },
+  {
+    "type": "try",
+    "named": false
+  },
+  {
+    "type": "typeid",
+    "named": false
+  },
+  {
+    "type": "typeof",
+    "named": false
+  },
+  {
+    "type": "ubyte",
+    "named": false
+  },
+  {
+    "type": "ucent",
+    "named": false
+  },
+  {
+    "type": "uint",
+    "named": false
+  },
+  {
+    "type": "ulong",
+    "named": false
+  },
+  {
+    "type": "union",
+    "named": false
+  },
+  {
+    "type": "unittest",
+    "named": false
+  },
+  {
+    "type": "ushort",
+    "named": false
+  },
+  {
+    "type": "version",
+    "named": false
+  },
+  {
+    "type": "void",
+    "named": false
+  },
+  {
+    "type": "wchar",
+    "named": false
+  },
+  {
+    "type": "while",
+    "named": false
+  },
+  {
+    "type": "with",
+    "named": false
+  },
+  {
+    "type": "word",
+    "named": false
+  },
+  {
+    "type": "wysiwyg_string",
+    "named": true
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "|",
+    "named": false
+  },
+  {
+    "type": "|=",
+    "named": false
+  },
+  {
+    "type": "||",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  },
+  {
+    "type": "~",
+    "named": false
+  },
+  {
+    "type": "~=",
+    "named": false
+  }
+]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -1,0 +1,223 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+};
+
+/*
+ *  Lexer Macros
+ */
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value            \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value,           \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_


### PR DESCRIPTION
Continuation of #8.

This PR includes most build files into repository.

To address the question from #8:

> I don't think it's a great idea to put binaries / artifacts (parser.c) into the source repository, it would probably make more sense to put those into a release archive, e.g. from github actions. Does helix support loading the parser from a release zip file?

It might make sense, but almost all treesitter grammar has artifacts committed into the repository.
Here are some:

1. https://github.com/briot/tree-sitter-ada
2. https://github.com/tree-sitter/tree-sitter-agda
3. https://github.com/aheber/tree-sitter-sfapex
4. https://github.com/tree-sitter/tree-sitter-bash
5. https://github.com/zwpaper/tree-sitter-beancount
6. https://github.com/amaanq/tree-sitter-capnp
7. https://github.com/tree-sitter/tree-sitter-c
8. https://github.com/tree-sitter/tree-sitter-cpp
9. https://github.com/tree-sitter/tree-sitter-c-sharp
10. https://github.com/sogaiu/tree-sitter-clojure
11. https://github.com/uyha/tree-sitter-cmake
12. https://github.com/stsewd/tree-sitter-comment

That was the first 12 parsers in https://tree-sitter.github.io/tree-sitter/#parsers, so it is safe to say that a lot of them does this, **including the ones from tree-sitter themselves**.

The other advantage of this approach is that you don't need Node.js, npm, and tree-sitter-cli just to install a language.

As for binding.gyp, it is needed, because if you read the generated binding.gyp:

```python
{
  "targets": [
    {
      "target_name": "tree_sitter_d_binding",
      "include_dirs": [
        "<!(node -e \"require('nan')\")",
        "src"
      ],
      "sources": [
        "bindings/node/binding.cc",
        "src/parser.c",
        # If your language uses an external scanner, add it here.
      ],
      "cflags_c": [
        "-std=c99",
      ]
    }
  ]
}
```

You can see that scanner.cc wasn't included!

From https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners:

> Then, add another C or C++ source file to your project. Currently, its path must be src/scanner.c or src/scanner.cc for the CLI to recognize it. Be sure to add this file to the sources section of your binding.gyp file so that it will be included when your project is compiled by Node.js and uncomment the appropriate block in your bindings/rust/build.rs file so that it will be included in your Rust crate.